### PR TITLE
Configure R2 download prefix for quotation PDFs

### DIFF
--- a/functions/downloads/[slug].ts
+++ b/functions/downloads/[slug].ts
@@ -7,11 +7,13 @@ function getCookie(raw: string, key: string) {
   return map[key];
 }
 
-export const onRequestGet: PagesFunction<{ DB: D1Database, R2: R2Bucket }> =
+export const onRequestGet: PagesFunction<{ DB: D1Database, R2: R2Bucket, DOWNLOADS_PREFIX?: string }> =
 async ({ request, env, params }) => {
   const slug = String(params.slug || "");
   const ticket = getCookie(request.headers.get("Cookie") || "", "dl_ticket");
   const baseHeaders = { "X-Robots-Tag": "noindex, nofollow" };
+
+  const keyPrefix = (env.DOWNLOADS_PREFIX || "downloads").replace(/\/+$/, "");
 
   if (!slug || !ticket) {
     return new Response("Forbidden", { status: 403, headers: baseHeaders });
@@ -25,7 +27,7 @@ async ({ request, env, params }) => {
     return new Response("Expired", { status: 403, headers: baseHeaders });
   }
 
-  const obj = await env.R2.get(`files/${slug}.pdf`);
+  const obj = await env.R2.get(`${keyPrefix}/${slug}.pdf`);
   if (!obj) {
     return new Response("Not Found", { status: 404, headers: baseHeaders });
   }

--- a/layouts/download.html
+++ b/layouts/download.html
@@ -3,7 +3,7 @@
     <h1>{{ .Title }}</h1>
     {{ .Content }}
 
-    {{/* 下载前置表单：slug 必须与 R2 的文件名去掉 .pdf 后一致 */}}
+    {{/* 下载前置表单：slug 必须与 R2 downloads/ 目录下的文件名去掉 .pdf 后一致 */}}
     {{ partial "lead-form.html" (dict
         "type" "download"
         "slug" "Baoheng-Quotation"


### PR DESCRIPTION
## Summary
- allow the downloads function to read PDFs from a configurable R2 key prefix
- clarify the download page instructions to reference the downloads/ directory

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e21a7ab350832c9f1d0f4caa6c8248