### PR TITLE
Fix header overlap by adjusting layout spacing

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -1,6 +1,5 @@
 
 .site-header {
-  --header-height: 72px;    /* 导航栏高度 */
   --burger-length: 30px;      /* 汉堡线长 */
   --burger-thickness: 3px;    /* 汉堡线粗 */
   --burger-gap: 6px;          /* 汉堡线间距 */
@@ -26,6 +25,16 @@
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   transition: var(--header-transition);
+}
+
+body {
+  --header-offset: var(--header-height);
+  padding-top: var(--header-offset);
+  transition: padding-top var(--t-normal) var(--ease);
+}
+
+body.header-hidden {
+  --header-offset: 0px;
 }
 
 .site-header.is-scrolled {

--- a/assets/scss/_tokens.scss
+++ b/assets/scss/_tokens.scss
@@ -28,6 +28,7 @@
   --container:        72rem; /* 默认：常规页面 */
   --container-wide:   80rem; /* 宽版：营销/视觉模块 */
   --container-narrow: 60rem; /* 窄版：以阅读为主 */
+  --header-height:    72px;  /* 顶部导航栏高度 */
 
   /* 字体与排版 */
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -114,6 +114,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     const header = document.getElementById('site-header');
     const body = document.body;
+    const bodyHiddenClass = 'header-hidden';
 
     // --- 1. 智能导航栏 (Smart Header) 逻辑 ---
     if (header) {
@@ -132,6 +133,7 @@
         // 在页面顶部时，始终显示导航栏
         if (currentScrollY <= scrollThreshold) {
           header.classList.remove('is-hidden');
+          body.classList.remove(bodyHiddenClass);
           lastScrollY = currentScrollY;
           return;
         }
@@ -144,10 +146,12 @@
         // 向上滚动 (显示)
         if (currentScrollY < lastScrollY) {
           header.classList.remove('is-hidden');
+          body.classList.remove(bodyHiddenClass);
         }
         // 向下滚动 (隐藏)
         else if (currentScrollY > lastScrollY) {
           header.classList.add('is-hidden');
+          body.classList.add(bodyHiddenClass);
         }
 
         // 更新上一次滚动位置


### PR DESCRIPTION
## Summary
- expose the header height token globally so page layout can reserve space for the fixed navigation bar
- add body padding that matches the header height and toggle it when the header hides on scroll to prevent content overlap
- update the header script to keep the body offset in sync with the header visibility state

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e48e2263d0832c9c9dc47588bb3194