### PR TITLE
Fix resource center navigation and metadata

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -121,28 +121,34 @@ weight = 20
   weight = 25
 
 [[main]]
-name = "资源中心"
+name = "Resources"
 url = "/resources/"
 identifier = "resources"
 weight = 30
 
   [[main]]
-  name = "博客/新闻"
+  name = "Insights"
   url = "/resources/articles/"
   parent = "resources"
   weight = 31
 
   [[main]]
-  name = "下载中心"
-  url = "/resources/downloads/"
+  name = "Newsroom"
+  url = "/resources/news/"
   parent = "resources"
   weight = 32
 
   [[main]]
-  name = "常见问题 (FAQ)"
-  url = "/resources/faq/"
+  name = "Downloads"
+  url = "/resources/downloads/"
   parent = "resources"
   weight = 33
+
+  [[main]]
+  name = "FAQ"
+  url = "/resources/faq/"
+  parent = "resources"
+  weight = 34
 
 [[main]]
 name = "关于我们"

--- a/config/_default/menus.zh.yaml
+++ b/config/_default/menus.zh.yaml
@@ -111,18 +111,22 @@ main:
     identifier: "resources"
     weight: 30
 
-  - name: "行业洞察 (博客/新闻)"
-    url: "/resources/blog-news/"
+  - name: "行业洞察 (博客)"
+    url: "/resources/articles/"
     parent: "resources"
     weight: 31
+  - name: "企业动态 (新闻)"
+    url: "/resources/news/"
+    parent: "resources"
+    weight: 32
   - name: "下载中心 (规格书/认证)"
     url: "/resources/downloads/"
     parent: "resources"
-    weight: 32
+    weight: 33
   - name: "常见问题 (FAQ)"
     url: "/resources/faq/"
     parent: "resources"
-    weight: 33
+    weight: 34
 
   # ====================================================================================
   # 4. 关于我们 (Level 1)

--- a/content/english/resources/_index.md
+++ b/content/english/resources/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Resources"
+description: "Find expert insights, company news, downloadable assets, and answers to common questions."
+aliases:
+  - "/resources/blog-news/"
+hero:
+  title: "Resource Center"
+  subtitle: "Stay ahead with the latest knowledge, certifications, and support from the GlobalTech team."
+sections:
+  - label: "Insights"
+    url: "/resources/articles/"
+    summary: "Thought leadership articles and best practices for smarter logistics."
+  - label: "Newsroom"
+    url: "/resources/news/"
+    summary: "Company announcements, milestones, and event highlights."
+  - label: "Downloads"
+    url: "/resources/downloads/"
+    summary: "Specification sheets, compliance certificates, and helpful checklists."
+  - label: "FAQ"
+    url: "/resources/faq/"
+    summary: "Quick answers to the questions we hear most from our customers."
+---

--- a/content/english/resources/articles/_index.md
+++ b/content/english/resources/articles/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "articles"
-description: "Insights and updates from our engineering team."
+title: "Insights"
+description: "Deep dives into pallet design, material handling trends, and best practices from our experts."
 ---
 

--- a/content/english/resources/downloads/_index.md
+++ b/content/english/resources/downloads/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "downloads"
-description: "Insights and updates from our engineering team."
+title: "Downloads"
+description: "Access specification sheets, certification documents, and helpful checklists for every pallet line."
 ---
 

--- a/content/english/resources/faq/_index.md
+++ b/content/english/resources/faq/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "faq"
-description: "Insights and updates from our engineering team."
+title: "FAQ"
+description: "Answers to the most common questions about plastic pallet performance, customization, and logistics."
 ---
 

--- a/content/english/resources/news/_index.md
+++ b/content/english/resources/news/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "news"
-description: "Insights and updates from our engineering team."
+title: "Newsroom"
+description: "Stay informed with the latest company updates, partnerships, and trade-show appearances."
 ---
 


### PR DESCRIPTION
## Summary
- align Chinese and English resource center menus with live sections and add a dedicated newsroom link
- restore the resource center landing page with hero, section summaries, and alias for the old blog-news path
- refresh section metadata to use descriptive titles and copy across insights, downloads, news, and FAQ hubs

## Testing
- hugo *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68e4e684ccb8832cb3391eabd08b307c