### PR TITLE
Rework mobile drawer slide-down and language dropdown

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -286,74 +286,50 @@ body.header-hidden {
 /* 语言切换 */
 .lang-switcher {
   position: relative;
+  color: var(--on-brand);
+  min-width: 160px;
 }
 
-.lang-switcher__button {
-  display: flex;
-  align-items: center;
-  gap: var(--space);
-  background: transparent;
-  border: none;
-  padding: var(--space) calc(var(--space) * 1);
-  border-radius: var(--radius);
-  color: var(--on-brand); 
-  transition: color var(--t-normal) var(--ease), background-color var(--t-normal) var(--ease);
-}
-
-.lang-switcher__button:hover {
-  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
-}
-
-.lang-switcher__button svg {
-  width: 20px;
-  height: 20px;
-}
-
-/* 语言下拉菜单 */
-.lang-switcher__dropdown {
-  position: absolute;
-  top: calc(100% - var(--border-w));
-  right: 0;
-  min-width: 150px;
-  background-color: var(--surface);
-  border-radius: 0;
-  box-shadow: var(--shadow);
-  border: var(--border-w) solid var(--border);
-  padding: var(--space);
-  margin-top: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(calc(var(--space) * -1));
-  transition: opacity var(--t-normal) var(--ease), transform var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
-}
-
-.lang-switcher:hover .lang-switcher__dropdown,
-.lang-switcher:focus-within .lang-switcher__dropdown {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.lang-switcher__dropdown a {
-  display: block;
-  padding: calc(var(--space) ) calc(var(--space) * 3);
-  color: var(--on-surface);
-  border-radius: 0;
-  white-space: nowrap;
-}
-
-.lang-switcher__dropdown::before {
+.lang-switcher::after {
   content: "";
   position: absolute;
-  left: 0; right: 0;
-  height: calc(var(--space) * 1.5);
-  top: calc(-1 * calc(var(--space) * 1.5));
+  pointer-events: none;
+  right: calc(var(--space) * 1.5);
+  top: 50%;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-60%) rotate(45deg);
 }
 
-.lang-switcher__dropdown a:hover {
-  background-color: var(--brand);
-  color: var(--on-brand);
-  text-decoration: none;
+.lang-switcher__select {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  color: inherit;
+  background-color: unquote("rgb(from var(--on-brand) r g b / 12%)");
+  border: none;
+  border-radius: var(--radius);
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 4) calc(var(--space) * 1.5) calc(var(--space) * 2.5);
+  cursor: pointer;
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
+  min-width: 100%;
+}
+
+.lang-switcher__select:hover,
+.lang-switcher__select:focus-visible {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 18%)");
+}
+
+.lang-switcher__select:focus-visible {
+  outline: 2px solid var(--on-brand);
+  outline-offset: 2px;
+}
+
+.lang-switcher__select option {
+  color: var(--on-surface);
+  background-color: var(--surface);
 }
 
 /* 汉堡按钮 (移动端) */
@@ -422,21 +398,25 @@ body[data-drawer-open="true"] #site-header {
   transition: opacity var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
 }
 
+
 .drawer {
   position: fixed;
-  top: 0;
+  top: var(--header-height);
+  left: 0;
   right: 0;
-  bottom: 0;
-  width: 80%;
-  max-width: 320px;
+  height: calc(100vh - var(--header-height));
+  max-height: calc(100vh - var(--header-height));
+  width: 100%;
   background-color: var(--brand);
   background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
   z-index: var(--z-modal);
-  transform: translateX(100%);
+  transform: translateY(-100%);
   transition: transform var(--t-normal) var(--ease);
   display: flex;
   flex-direction: column;
   padding: calc(var(--space) * 4);
+  box-shadow: var(--shadow);
+  border-bottom: var(--border-w) solid var(--border);
 }
 
 body[data-drawer-open='true'] .drawer-overlay {
@@ -445,7 +425,7 @@ body[data-drawer-open='true'] .drawer-overlay {
 }
 
 body[data-drawer-open='true'] .drawer {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 body[data-drawer-open='true'] {
@@ -481,6 +461,48 @@ body[data-drawer-open='true'] {
   transition: background-color var(--t-normal) var(--ease);
 }
 
+.drawer__menu-row {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__menu-row > a {
+  flex: 1 1 auto;
+}
+
+.submenu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--on-brand);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+
+.submenu-toggle:hover,
+.submenu-toggle:focus-visible {
+  background-color: var(--brand);
+  color: var(--on-brand);
+  outline: none;
+}
+
+.submenu-toggle svg {
+  width: 18px;
+  height: 18px;
+  transition: transform var(--t-normal) var(--ease);
+}
+
+.drawer__menu li.is-open > .drawer__menu-row .submenu-toggle svg {
+  transform: rotate(90deg);
+}
+
 .drawer__menu a:hover,
 .drawer__menu a.is-active {
   background-color: var(--brand);
@@ -494,14 +516,39 @@ body[data-drawer-open='true'] {
 }
 
 /* 移动端子菜单样式 */
+.drawer__menu .submenu-panel {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: max-height var(--t-normal) var(--ease), opacity var(--t-normal) var(--ease), transform var(--t-normal) var(--ease);
+}
+
+.drawer__menu li.is-open > .submenu-panel {
+  max-height: 2000px;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
 .drawer__menu .submenu {
-  padding-left: calc(var(--space) * 4);
-  margin-top: calc(var(--space) * -1);
+  list-style: none;
+  margin: 0;
+  padding: calc(var(--space) * 1) 0 0 calc(var(--space) * 3);
+}
+
+.drawer__menu .submenu--level3 {
+  padding-left: calc(var(--space) * 5);
 }
 
 .drawer__menu .submenu a {
   font-size: var(--fs-1);
   padding-block: calc(var(--space) * 2);
+}
+
+.drawer__menu .submenu li + li {
+  margin-top: calc(var(--space) * 1);
 }
 
 .drawer__footer {
@@ -510,9 +557,13 @@ body[data-drawer-open='true'] {
   border-top: var(--border-w) solid var(--border);
 }
 
-.drawer__footer .lang-switcher__button {
+.drawer__footer .lang-switcher {
   width: 100%;
-  justify-content: center;
+}
+
+.drawer__footer .lang-switcher__select {
+  width: 100%;
+  background-color: unquote("rgb(from var(--on-brand) r g b / 16%)");
 }
 
 /*

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -78,24 +78,27 @@
 
     <div class="navbar__actions">
       {{ if hugo.IsMultilingual }}
-      <div class="lang-switcher">
-        <button class="lang-switcher__button">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5"
-            stroke="currentColor" aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path d="M2 12h20"></path>
-            <path d="M12 2a15.75 15.75 0 0 1 0 20"></path>
-            <path d="M12 2a15.75 15.75 0 0 0 0 20"></path>
-          </svg>
-          <span>{{ .Site.Language.LanguageName }}</span>
-        </button>
-        <div class="lang-switcher__dropdown">
-          {{ range .Site.Home.AllTranslations }}
-          {{ if ne .Language.Lang $.Site.Language.Lang }}
-          <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+      <div class="lang-switcher" data-lang-switcher>
+        {{ $currentPage := . }}
+        {{ $languageOptions := slice $currentPage }}
+        {{ range .Translations }}
+        {{ $languageOptions = $languageOptions | append . }}
+        {{ end }}
+        {{ range .Site.Home.AllTranslations }}
+        {{ $lang := .Language.Lang }}
+        {{ if not (first 1 (where $languageOptions "Language.Lang" $lang)) }}
+        {{ $languageOptions = $languageOptions | append . }}
+        {{ end }}
+        {{ end }}
+        {{ $languageOptions = sort $languageOptions "Language.Weight" }}
+        <label class="sr-only" for="lang-switcher-desktop">{{ i18n "language_switcher_label" | default "选择语言" }}</label>
+        <select id="lang-switcher-desktop" class="lang-switcher__select">
+          {{ range $languageOptions }}
+          <option value="{{ .RelPermalink }}" {{ if eq .Language.Lang $currentPage.Language.Lang }}selected{{ end }}>
+            {{ .Language.LanguageName }}
+          </option>
           {{ end }}
-          {{ end }}
-        </div>
+        </select>
       </div>
       {{ end }}
 
@@ -119,15 +122,47 @@
     <ul>
       {{ range .Site.Menus.main }}
       {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
-          {{ range .Children }}
-          {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-          <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
+      <li class="drawer__menu-item{{ if .HasChildren }} has-children{{ end }}">
+        <div class="drawer__menu-row">
+          <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
+          {{ if .HasChildren }}
+          <button type="button" class="submenu-toggle" aria-expanded="false" aria-label="切换{{ .Name }}子菜单">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M7.293 4.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L10.586 10 7.293 6.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
           {{ end }}
-        </ul>
+        </div>
+        {{ if .HasChildren }}
+        <div class="submenu-panel">
+          <ul class="submenu submenu--level2">
+            {{ range .Children }}
+            {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+            <li class="drawer__submenu-item{{ if .HasChildren }} has-children{{ end }}">
+              <div class="drawer__menu-row">
+                <a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a>
+                {{ if .HasChildren }}
+                <button type="button" class="submenu-toggle" aria-expanded="false" aria-label="切换{{ .Name }}子菜单">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M7.293 4.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L10.586 10 7.293 6.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+                {{ end }}
+              </div>
+              {{ if .HasChildren }}
+              <div class="submenu-panel">
+                <ul class="submenu submenu--level3">
+                  {{ range .Children }}
+                  {{ $grandchildActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+                  <li><a href="{{ .URL | relLangURL }}" class="{{ if $grandchildActive }}is-active{{ end }}">{{ .Name }}</a></li>
+                  {{ end }}
+                </ul>
+              </div>
+              {{ end }}
+            </li>
+            {{ end }}
+          </ul>
+        </div>
         {{ end }}
       </li>
       {{ end }}
@@ -136,10 +171,27 @@
 
   {{ if hugo.IsMultilingual }}
   <div class="drawer__footer">
-    <div class="lang-switcher">
-      {{ range .Site.Home.AllTranslations }}
-      <a class="lang-switcher__button" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+    <div class="lang-switcher" data-lang-switcher>
+      {{ $currentPage := . }}
+      {{ $languageOptions := slice $currentPage }}
+      {{ range .Translations }}
+      {{ $languageOptions = $languageOptions | append . }}
       {{ end }}
+      {{ range .Site.Home.AllTranslations }}
+      {{ $lang := .Language.Lang }}
+      {{ if not (first 1 (where $languageOptions "Language.Lang" $lang)) }}
+      {{ $languageOptions = $languageOptions | append . }}
+      {{ end }}
+      {{ end }}
+      {{ $languageOptions = sort $languageOptions "Language.Weight" }}
+      <label class="sr-only" for="lang-switcher-mobile">{{ i18n "language_switcher_label" | default "选择语言" }}</label>
+      <select id="lang-switcher-mobile" class="lang-switcher__select">
+        {{ range $languageOptions }}
+        <option value="{{ .RelPermalink }}" {{ if eq .Language.Lang $currentPage.Language.Lang }}selected{{ end }}>
+          {{ .Language.LanguageName }}
+        </option>
+        {{ end }}
+      </select>
     </div>
   </div>
   {{ end }}
@@ -243,6 +295,46 @@
       if (event.key === 'Escape' && body.getAttribute('data-drawer-open') === 'true') {
         closeDrawer();
       }
+    });
+
+    const drawerMenu = document.querySelector('.drawer__menu');
+    if (drawerMenu) {
+      drawerMenu.addEventListener('click', (event) => {
+        const toggle = event.target.closest('.submenu-toggle');
+        if (!toggle) return;
+
+        event.preventDefault();
+
+        const menuItem = toggle.closest('li');
+        if (!menuItem) return;
+
+        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        const nextState = !isExpanded;
+
+        toggle.setAttribute('aria-expanded', nextState ? 'true' : 'false');
+        menuItem.classList.toggle('is-open', nextState);
+
+        if (!nextState) {
+          const openDescendants = menuItem.querySelectorAll('li.is-open');
+          openDescendants.forEach((item) => {
+            item.classList.remove('is-open');
+            const descendantToggle = item.querySelector('.submenu-toggle');
+            if (descendantToggle) {
+              descendantToggle.setAttribute('aria-expanded', 'false');
+            }
+          });
+        }
+      });
+    }
+
+    const langSwitchers = document.querySelectorAll('[data-lang-switcher] .lang-switcher__select');
+    langSwitchers.forEach((select) => {
+      select.addEventListener('change', () => {
+        const target = select.value;
+        if (target) {
+          window.location.href = target;
+        }
+      });
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- convert the mobile drawer to slide down from beneath the header and enlarge submenu toggles for better touch targets
- restyle the language switcher into a select dropdown with shared navigation logic for desktop and mobile

## Testing
- hugo --minify *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e552f19a64832cb7f9d45bd3f96438