### PR TITLE
Overhaul mobile drawer navigation flow

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -286,74 +286,55 @@ body.header-hidden {
 /* 语言切换 */
 .lang-switcher {
   position: relative;
+  color: var(--on-brand);
+  min-width: 160px;
 }
 
-.lang-switcher__button {
-  display: flex;
-  align-items: center;
-  gap: var(--space);
-  background: transparent;
-  border: none;
-  padding: var(--space) calc(var(--space) * 1);
-  border-radius: var(--radius);
-  color: var(--on-brand); 
-  transition: color var(--t-normal) var(--ease), background-color var(--t-normal) var(--ease);
-}
-
-.lang-switcher__button:hover {
-  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
-}
-
-.lang-switcher__button svg {
-  width: 20px;
-  height: 20px;
-}
-
-/* 语言下拉菜单 */
-.lang-switcher__dropdown {
-  position: absolute;
-  top: calc(100% - var(--border-w));
-  right: 0;
-  min-width: 150px;
-  background-color: var(--surface);
-  border-radius: 0;
-  box-shadow: var(--shadow);
-  border: var(--border-w) solid var(--border);
-  padding: var(--space);
-  margin-top: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(calc(var(--space) * -1));
-  transition: opacity var(--t-normal) var(--ease), transform var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
-}
-
-.lang-switcher:hover .lang-switcher__dropdown,
-.lang-switcher:focus-within .lang-switcher__dropdown {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.lang-switcher__dropdown a {
-  display: block;
-  padding: calc(var(--space) ) calc(var(--space) * 3);
-  color: var(--on-surface);
-  border-radius: 0;
-  white-space: nowrap;
-}
-
-.lang-switcher__dropdown::before {
+.lang-switcher::after {
   content: "";
   position: absolute;
-  left: 0; right: 0;
-  height: calc(var(--space) * 1.5);
-  top: calc(-1 * calc(var(--space) * 1.5));
+  pointer-events: none;
+  right: calc(var(--space) * 1.5);
+  top: 50%;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-60%) rotate(45deg);
 }
 
-.lang-switcher__dropdown a:hover {
-  background-color: var(--brand);
-  color: var(--on-brand);
-  text-decoration: none;
+.lang-switcher__select {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  color: inherit;
+  background-color: unquote("rgb(from var(--on-brand) r g b / 12%)");
+  border: none;
+  border-radius: var(--radius);
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 4) calc(var(--space) * 1.5) calc(var(--space) * 2.5);
+  cursor: pointer;
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
+  min-width: 100%;
+}
+
+.lang-switcher__select:hover,
+.lang-switcher__select:focus-visible {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 18%)");
+}
+
+.lang-switcher__select:focus-visible {
+  outline: 2px solid var(--on-brand);
+  outline-offset: 2px;
+}
+
+.lang-switcher__select option {
+  color: var(--on-surface);
+  background-color: var(--surface);
+}
+
+.lang-switcher--mobile {
+  width: 100%;
+  min-width: 0;
 }
 
 /* 汉堡按钮 (移动端) */
@@ -420,99 +401,215 @@ body[data-drawer-open="true"] #site-header {
   opacity: 0;
   visibility: hidden;
   transition: opacity var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
+  pointer-events: none;
 }
+
 
 .drawer {
   position: fixed;
-  top: 0;
+  top: var(--header-height);
+  left: 0;
   right: 0;
-  bottom: 0;
-  width: 80%;
-  max-width: 320px;
+  height: calc(100vh - var(--header-height));
+  max-height: calc(100vh - var(--header-height));
+  width: 100%;
   background-color: var(--brand);
   background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
   z-index: var(--z-modal);
-  transform: translateX(100%);
+  transform: translateY(-100%);
   transition: transform var(--t-normal) var(--ease);
   display: flex;
   flex-direction: column;
   padding: calc(var(--space) * 4);
+  box-shadow: var(--shadow);
+  border-bottom: var(--border-w) solid var(--border);
 }
 
 body[data-drawer-open='true'] .drawer-overlay {
   opacity: 1;
   visibility: visible;
+  pointer-events: auto;
 }
 
 body[data-drawer-open='true'] .drawer {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 body[data-drawer-open='true'] {
   overflow: hidden;
 }
 
-.drawer__header {
+.drawer__viewport {
+  flex: 1;
+  min-height: 0;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: calc(var(--space) * 6);
+  position: relative;
 }
 
-
-.drawer__menu {
-  flex-grow: 1;
+.drawer__panel {
+  display: none;
+  flex-direction: column;
+  gap: calc(var(--space) * 3);
+  width: 100%;
+  height: 100%;
   overflow-y: auto;
 }
 
-.drawer__menu ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.drawer__panel.is-active {
+  display: flex;
 }
 
-.drawer__menu a {
+.drawer__panel-header {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+  margin-bottom: calc(var(--space) * 2);
+}
+
+.drawer__panel-title {
+  font-size: var(--fs-4);
+  font-weight: 600;
+  color: var(--on-brand);
+}
+
+.drawer__menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__menu-list--level1 {
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__menu-list--level2 {
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__menu-list--level3 {
+  gap: calc(var(--space) * 1);
+  padding-left: calc(var(--space) * 4);
+}
+
+.drawer__item {
+  position: relative;
+}
+
+.drawer__item-row {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item-row .drawer__link {
+  flex: 1 1 auto;
+}
+
+.drawer__link {
   display: block;
-  padding: calc(var(--space) * 3) calc(var(--space) * 2);
+  width: 100%;
+  padding: calc(var(--space) * 2.5) calc(var(--space) * 2);
   font-size: var(--fs-2);
+  font-weight: 600;
   color: var(--on-brand);
   border-radius: var(--radius);
   text-decoration: none;
-  transition: background-color var(--t-normal) var(--ease);
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
 }
 
-.drawer__menu a:hover,
-.drawer__menu a.is-active {
-  background-color: var(--brand);
-  color: var(--on-brand);
+.drawer__menu-list--level2 > .drawer__item > .drawer__link {
+  font-size: var(--fs-2);
+  font-weight: 500;
+  padding: calc(var(--space) * 2) calc(var(--space) * 2);
 }
 
-[data-theme="dark"] .drawer__menu a:hover,
-[data-theme="dark"] .drawer__menu a.is-active {
-  background-color: var(--brand);
-  color: var(--on-brand);
-}
-
-/* 移动端子菜单样式 */
-.drawer__menu .submenu {
-  padding-left: calc(var(--space) * 4);
-  margin-top: calc(var(--space) * -1);
-}
-
-.drawer__menu .submenu a {
+.drawer__menu-list--level3 .drawer__link {
   font-size: var(--fs-1);
-  padding-block: calc(var(--space) * 2);
+  font-weight: 400;
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 2);
 }
 
-.drawer__footer {
-  padding-top: calc(var(--space) * 4);
-  margin-top: auto;
-  border-top: var(--border-w) solid var(--border);
+.drawer__link:hover,
+.drawer__link.is-active {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 18%)");
+  color: var(--on-brand);
 }
 
-.drawer__footer .lang-switcher__button {
-  width: 100%;
+.drawer__forward,
+.drawer__back,
+.drawer__language-toggle {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  gap: calc(var(--space) * 1.5);
+  width: auto;
+  min-height: 44px;
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 2);
+  background-color: transparent;
+  border: none;
+  color: var(--on-brand);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+
+.drawer__forward {
+  width: 48px;
+  padding: 0;
+}
+
+.drawer__back {
+  justify-content: flex-start;
+}
+
+.drawer__forward svg,
+.drawer__back svg,
+.drawer__language-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.drawer__forward:hover,
+.drawer__forward:focus-visible,
+.drawer__back:hover,
+.drawer__back:focus-visible,
+.drawer__language-toggle:hover,
+.drawer__language-toggle:focus-visible {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
+  color: var(--on-brand);
+  outline: none;
+}
+
+.drawer__language-toggle {
+  justify-content: space-between;
+  width: 100%;
+  font-size: var(--fs-2);
+  font-weight: 500;
+}
+
+.drawer__language {
+  margin-top: auto;
+  padding-top: calc(var(--space) * 3);
+  border-top: var(--border-w) solid unquote("rgb(from var(--on-brand) r g b / 25%)");
+}
+
+.drawer__language-panel {
+  margin-top: calc(var(--space) * 2);
+}
+
+.drawer__language-panel select {
+  width: 100%;
+}
+
+.drawer__menu-list--level2 .drawer__menu-list--level3 {
+  margin-top: calc(var(--space) * 1.5);
+}
+
+.drawer--showing-subview .drawer__language {
+  display: none;
 }
 
 /*
@@ -520,12 +617,21 @@ body[data-drawer-open='true'] {
         */
 @media (max-width: 1023.98px) {
 
-  .navbar__menu,
-  .navbar__actions .lang-switcher {
+  .navbar__menu {
+    display: none;
+  }
+
+  .lang-switcher--desktop {
     display: none;
   }
 
   .navbar__toggler {
     display: flex;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lang-switcher--mobile {
+    display: none;
   }
 }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,19 @@
+{{ if hugo.IsMultilingual }}
+  {{ $currentPage := . }}
+  {{ $languageOptions := slice $currentPage }}
+  {{ range .Translations }}
+    {{ $languageOptions = $languageOptions | append . }}
+  {{ end }}
+  {{ range .Site.Home.AllTranslations }}
+    {{ $lang := .Language.Lang }}
+    {{ if not (first 1 (where $languageOptions "Language.Lang" $lang)) }}
+      {{ $languageOptions = $languageOptions | append . }}
+    {{ end }}
+  {{ end }}
+  {{ $languageOptions = sort $languageOptions "Language.Weight" }}
+  {{ $.Scratch.Set "languageOptions" $languageOptions }}
+{{ end }}
+
 <header class="site-header" id="site-header">
   <nav class="navbar">
 
@@ -78,28 +94,24 @@
 
     <div class="navbar__actions">
       {{ if hugo.IsMultilingual }}
-      <div class="lang-switcher">
-        <button class="lang-switcher__button">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5"
-            stroke="currentColor" aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path d="M2 12h20"></path>
-            <path d="M12 2a15.75 15.75 0 0 1 0 20"></path>
-            <path d="M12 2a15.75 15.75 0 0 0 0 20"></path>
-          </svg>
-          <span>{{ .Site.Language.LanguageName }}</span>
-        </button>
-        <div class="lang-switcher__dropdown">
-          {{ range .Site.Home.AllTranslations }}
-          {{ if ne .Language.Lang $.Site.Language.Lang }}
-          <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
-          {{ end }}
-          {{ end }}
+        {{ $languageOptions := $.Scratch.Get "languageOptions" }}
+        {{ $languageLabel := i18n "language_switcher_label" | default "选择语言" }}
+        {{ $currentLang := $.Language.Lang }}
+        <div class="lang-switcher lang-switcher--desktop" data-lang-switcher>
+          <label class="sr-only" for="lang-switcher-desktop">{{ $languageLabel }}</label>
+          <select id="lang-switcher-desktop" class="lang-switcher__select">
+            {{ range $languageOptions }}
+              <option value="{{ .RelPermalink }}" {{ if eq .Language.Lang $currentLang }}selected{{ end }}>
+                {{ .Language.LanguageName }}
+              </option>
+            {{ end }}
+          </select>
         </div>
-      </div>
       {{ end }}
 
-      <button class="navbar__toggler" id="drawer-toggler" aria-label="Open menu">
+      {{ $openLabel := i18n "mobile_open_menu" | default "打开菜单" }}
+      {{ $closeLabel := i18n "mobile_close_menu" | default "关闭菜单" }}
+      <button class="navbar__toggler" id="drawer-toggler" aria-controls="drawer" aria-expanded="false" aria-label="{{ $openLabel }}" data-open-label="{{ $openLabel }}" data-close-label="{{ $closeLabel }}">
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
@@ -109,40 +121,90 @@
 </header>
 
 <div class="drawer-overlay" id="drawer-overlay"></div>
-<aside class="drawer" id="drawer">
-  <div class="drawer__header">
-    <span class="sr-only">Menu</span>
-  </div>
-
-  <nav class="drawer__menu" aria-label="Mobile navigation">
+<aside class="drawer" id="drawer" data-root-panel="root" aria-hidden="true">
+  <div class="drawer__viewport" data-drawer-viewport>
     {{ $current := . }}
-    <ul>
-      {{ range .Site.Menus.main }}
-      {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
-          {{ range .Children }}
-          {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-          <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
-          {{ end }}
-        </ul>
+    <section class="drawer__panel is-active" data-panel="root" aria-label="{{ i18n "mobile_primary_navigation" | default "主导航" }}">
+      <ul class="drawer__menu-list drawer__menu-list--level1">
+        {{ range $index, $item := .Site.Menus.main }}
+        {{ $active := or ($current.IsMenuCurrent "main" $item) ($current.HasMenuCurrent "main" $item) }}
+        {{ $panelID := printf "panel-%d" $index }}
+        <li class="drawer__item{{ if $item.HasChildren }} has-children{{ end }}">
+          <div class="drawer__item-row">
+            <a href="{{ $item.URL | relLangURL }}" class="drawer__link{{ if $active }} is-active{{ end }}">{{ $item.Name }}</a>
+            {{ if $item.HasChildren }}
+            <button type="button" class="drawer__forward" data-target="{{ $panelID }}" aria-label="{{ printf (i18n "mobile_view_submenu" | default "查看%s的子菜单") $item.Name }}">
+              <svg aria-hidden="true" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M7.293 4.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L10.586 10 7.293 6.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+            {{ end }}
+          </div>
+        </li>
         {{ end }}
-      </li>
-      {{ end }}
-    </ul>
-  </nav>
+      </ul>
 
-  {{ if hugo.IsMultilingual }}
-  <div class="drawer__footer">
-    <div class="lang-switcher">
-      {{ range .Site.Home.AllTranslations }}
-      <a class="lang-switcher__button" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+      {{ if and (hugo.IsMultilingual) ($.Scratch.Get "languageOptions") }}
+      {{ $languageOptions := $.Scratch.Get "languageOptions" }}
+      {{ $languageLabel := i18n "language_switcher_label" | default "选择语言" }}
+      {{ $currentLang := $.Language.Lang }}
+      <div class="drawer__language" data-lang-switcher>
+        <button type="button" class="drawer__language-toggle" aria-expanded="false">
+          <span>{{ $languageLabel }}</span>
+          <svg aria-hidden="true" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <div class="drawer__language-panel" hidden>
+          <label class="sr-only" for="lang-switcher-mobile">{{ $languageLabel }}</label>
+          <select id="lang-switcher-mobile" class="lang-switcher__select">
+            {{ range $languageOptions }}
+            <option value="{{ .RelPermalink }}" {{ if eq .Language.Lang $currentLang }}selected{{ end }}>
+              {{ .Language.LanguageName }}
+            </option>
+            {{ end }}
+          </select>
+        </div>
+      </div>
       {{ end }}
-    </div>
+    </section>
+
+    {{ range $index, $item := .Site.Menus.main }}
+    {{ if $item.HasChildren }}
+    {{ $panelID := printf "panel-%d" $index }}
+    <section class="drawer__panel" data-panel="{{ $panelID }}" aria-label="{{ $item.Name }}">
+      <div class="drawer__panel-header">
+        <button type="button" class="drawer__back" data-target="root">
+          <svg aria-hidden="true" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" d="M12.707 4.293a1 1 0 010 1.414L9.414 9l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+          </svg>
+          <span>{{ i18n "mobile_back_to_main" | default "返回" }}</span>
+        </button>
+        <span class="drawer__panel-title">{{ $item.Name }}</span>
+      </div>
+
+      <ul class="drawer__menu-list drawer__menu-list--level2">
+        {{ range $child := $item.Children }}
+        {{ $childActive := or ($current.IsMenuCurrent "main" $child) ($current.HasMenuCurrent "main" $child) }}
+        <li class="drawer__item{{ if $child.HasChildren }} has-grandchildren{{ end }}">
+          <a href="{{ $child.URL | relLangURL }}" class="drawer__link{{ if $childActive }} is-active{{ end }}">{{ $child.Name }}</a>
+          {{ if $child.HasChildren }}
+          <ul class="drawer__menu-list drawer__menu-list--level3">
+            {{ range $grandchild := $child.Children }}
+            {{ $grandchildActive := or ($current.IsMenuCurrent "main" $grandchild) ($current.HasMenuCurrent "main" $grandchild) }}
+            <li class="drawer__item">
+              <a href="{{ $grandchild.URL | relLangURL }}" class="drawer__link{{ if $grandchildActive }} is-active{{ end }}">{{ $grandchild.Name }}</a>
+            </li>
+            {{ end }}
+          </ul>
+          {{ end }}
+        </li>
+        {{ end }}
+      </ul>
+    </section>
+    {{ end }}
+    {{ end }}
   </div>
-  {{ end }}
 </aside>
 
 <script>
@@ -209,27 +271,117 @@
       handleSmartHeader();
     }
 
-    // --- 2. 抽屉 (Drawer) 逻辑 (保持不变) ---
+    // --- 2. 抽屉 (Drawer) 逻辑 ---
     const drawerToggler = document.getElementById('drawer-toggler');
     const drawerOverlay = document.getElementById('drawer-overlay');
+    const drawer = document.getElementById('drawer');
+    const rootPanelId = drawer ? drawer.getAttribute('data-root-panel') || 'root' : 'root';
+    const drawerViewport = drawer ? drawer.querySelector('[data-drawer-viewport]') : null;
+
+    const drawerPanels = drawer ? Array.from(drawer.querySelectorAll('.drawer__panel')) : [];
+    drawerPanels.forEach((panel) => {
+      const isActive = panel.classList.contains('is-active');
+      panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+    if (drawer) {
+      drawer.classList.toggle('drawer--showing-root', true);
+      drawer.setAttribute('data-active-panel', rootPanelId);
+    }
+
+    const drawerLanguage = drawer ? drawer.querySelector('.drawer__language') : null;
+    let collapseLanguagePanel = () => {};
+
+    if (drawerLanguage) {
+      const languageToggle = drawerLanguage.querySelector('.drawer__language-toggle');
+      const languagePanel = drawerLanguage.querySelector('.drawer__language-panel');
+
+      if (languageToggle && languagePanel) {
+        collapseLanguagePanel = () => {
+          languageToggle.setAttribute('aria-expanded', 'false');
+          languagePanel.hidden = true;
+        };
+
+        const expandLanguagePanel = () => {
+          languageToggle.setAttribute('aria-expanded', 'true');
+          languagePanel.hidden = false;
+        };
+
+        languageToggle.addEventListener('click', () => {
+          const expanded = languageToggle.getAttribute('aria-expanded') === 'true';
+          if (expanded) {
+            collapseLanguagePanel();
+          } else {
+            expandLanguagePanel();
+          }
+        });
+      }
+    }
+
+    const setActivePanel = (panelId) => {
+      if (!drawer) return;
+
+      const targetPanel = drawer.querySelector(`.drawer__panel[data-panel="${panelId}"]`);
+      if (!targetPanel) return;
+
+      const currentPanel = drawer.querySelector('.drawer__panel.is-active');
+      if (currentPanel && currentPanel !== targetPanel) {
+        currentPanel.classList.remove('is-active');
+        currentPanel.setAttribute('aria-hidden', 'true');
+      }
+
+      targetPanel.classList.add('is-active');
+      targetPanel.setAttribute('aria-hidden', 'false');
+      drawer.setAttribute('data-active-panel', panelId);
+
+      const isRoot = panelId === rootPanelId;
+      drawer.classList.toggle('drawer--showing-root', isRoot);
+      drawer.classList.toggle('drawer--showing-subview', !isRoot);
+
+      if (!isRoot) {
+        collapseLanguagePanel();
+      }
+    };
+
+    const setDrawerOpenState = (shouldOpen) => {
+      body.setAttribute('data-drawer-open', shouldOpen ? 'true' : 'false');
+
+      if (drawerToggler) {
+        drawerToggler.classList.toggle('open', shouldOpen);
+        drawerToggler.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+
+        const { openLabel = '打开菜单', closeLabel = '关闭菜单' } = drawerToggler.dataset;
+        drawerToggler.setAttribute('aria-label', shouldOpen ? closeLabel : openLabel);
+      }
+
+      if (drawer) {
+        drawer.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+        if (!shouldOpen) {
+          collapseLanguagePanel();
+        }
+      }
+
+      if (drawerOverlay) {
+        drawerOverlay.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+      }
+    };
 
     const openDrawer = () => {
-      body.setAttribute('data-drawer-open', 'true');
-      if (drawerToggler) drawerToggler.classList.add('open');
+      setActivePanel(rootPanelId);
+      setDrawerOpenState(true);
     };
+
     const closeDrawer = () => {
-      body.setAttribute('data-drawer-open', 'false');
-      if (drawerToggler) drawerToggler.classList.remove('open');
+      setActivePanel(rootPanelId);
+      setDrawerOpenState(false);
     };
 
     if (drawerToggler) {
-      drawerToggler.addEventListener('click', () => {
+      drawerToggler.addEventListener('click', (event) => {
+        event.preventDefault();
         const isOpen = body.getAttribute('data-drawer-open') === 'true';
         if (isOpen) {
-          // 关闭抽屉
           closeDrawer();
         } else {
-          // 打开抽屉
           openDrawer();
         }
       });
@@ -243,6 +395,37 @@
       if (event.key === 'Escape' && body.getAttribute('data-drawer-open') === 'true') {
         closeDrawer();
       }
+    });
+
+    if (drawerViewport) {
+      drawerViewport.addEventListener('click', (event) => {
+        const forward = event.target.closest('.drawer__forward');
+        if (forward) {
+          event.preventDefault();
+          const target = forward.getAttribute('data-target');
+          if (target) {
+            setActivePanel(target);
+          }
+          return;
+        }
+
+        const back = event.target.closest('.drawer__back');
+        if (back) {
+          event.preventDefault();
+          const target = back.getAttribute('data-target') || rootPanelId;
+          setActivePanel(target);
+        }
+      });
+    }
+
+    const langSwitchers = document.querySelectorAll('[data-lang-switcher] .lang-switcher__select');
+    langSwitchers.forEach((select) => {
+      select.addEventListener('change', () => {
+        const target = select.value;
+        if (target) {
+          window.location.href = target;
+        }
+      });
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- rebuild the mobile drawer markup into root and submenu panels with dedicated forward and back controls
- implement new drawer scripting to manage panel transitions, language dropdown toggling, and accessibility attributes
- restyle the drawer for top-down reveal, larger touch targets, and a footer language picker only on the root panel

## Testing
- hugo --minify *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e552f19a64832cb7f9d45bd3f96438