### PR TITLE
Rebuild mobile drawer navigation

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -286,74 +286,55 @@ body.header-hidden {
 /* 语言切换 */
 .lang-switcher {
   position: relative;
+  color: var(--on-brand);
+  min-width: 160px;
 }
 
-.lang-switcher__button {
-  display: flex;
-  align-items: center;
-  gap: var(--space);
-  background: transparent;
-  border: none;
-  padding: var(--space) calc(var(--space) * 1);
-  border-radius: var(--radius);
-  color: var(--on-brand); 
-  transition: color var(--t-normal) var(--ease), background-color var(--t-normal) var(--ease);
-}
-
-.lang-switcher__button:hover {
-  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
-}
-
-.lang-switcher__button svg {
-  width: 20px;
-  height: 20px;
-}
-
-/* 语言下拉菜单 */
-.lang-switcher__dropdown {
-  position: absolute;
-  top: calc(100% - var(--border-w));
-  right: 0;
-  min-width: 150px;
-  background-color: var(--surface);
-  border-radius: 0;
-  box-shadow: var(--shadow);
-  border: var(--border-w) solid var(--border);
-  padding: var(--space);
-  margin-top: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(calc(var(--space) * -1));
-  transition: opacity var(--t-normal) var(--ease), transform var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
-}
-
-.lang-switcher:hover .lang-switcher__dropdown,
-.lang-switcher:focus-within .lang-switcher__dropdown {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.lang-switcher__dropdown a {
-  display: block;
-  padding: calc(var(--space) ) calc(var(--space) * 3);
-  color: var(--on-surface);
-  border-radius: 0;
-  white-space: nowrap;
-}
-
-.lang-switcher__dropdown::before {
+.lang-switcher::after {
   content: "";
   position: absolute;
-  left: 0; right: 0;
-  height: calc(var(--space) * 1.5);
-  top: calc(-1 * calc(var(--space) * 1.5));
+  pointer-events: none;
+  right: calc(var(--space) * 1.5);
+  top: 50%;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-60%) rotate(45deg);
 }
 
-.lang-switcher__dropdown a:hover {
-  background-color: var(--brand);
-  color: var(--on-brand);
-  text-decoration: none;
+.lang-switcher__select {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  color: inherit;
+  background-color: unquote("rgb(from var(--on-brand) r g b / 12%)");
+  border: none;
+  border-radius: var(--radius);
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 4) calc(var(--space) * 1.5) calc(var(--space) * 2.5);
+  cursor: pointer;
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
+  min-width: 100%;
+}
+
+.lang-switcher__select:hover,
+.lang-switcher__select:focus-visible {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 18%)");
+}
+
+.lang-switcher__select:focus-visible {
+  outline: 2px solid var(--on-brand);
+  outline-offset: 2px;
+}
+
+.lang-switcher__select option {
+  color: var(--on-surface);
+  background-color: var(--surface);
+}
+
+.lang-switcher--mobile {
+  width: 100%;
+  min-width: 0;
 }
 
 /* 汉堡按钮 (移动端) */
@@ -422,21 +403,25 @@ body[data-drawer-open="true"] #site-header {
   transition: opacity var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
 }
 
+
 .drawer {
   position: fixed;
-  top: 0;
+  top: var(--header-height);
+  left: 0;
   right: 0;
-  bottom: 0;
-  width: 80%;
-  max-width: 320px;
+  height: calc(100vh - var(--header-height));
+  max-height: calc(100vh - var(--header-height));
+  width: 100%;
   background-color: var(--brand);
   background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
   z-index: var(--z-modal);
-  transform: translateX(100%);
+  transform: translateY(-100%);
   transition: transform var(--t-normal) var(--ease);
   display: flex;
   flex-direction: column;
   padding: calc(var(--space) * 4);
+  box-shadow: var(--shadow);
+  border-bottom: var(--border-w) solid var(--border);
 }
 
 body[data-drawer-open='true'] .drawer-overlay {
@@ -445,7 +430,7 @@ body[data-drawer-open='true'] .drawer-overlay {
 }
 
 body[data-drawer-open='true'] .drawer {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 body[data-drawer-open='true'] {
@@ -462,57 +447,242 @@ body[data-drawer-open='true'] {
 
 .drawer__menu {
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.drawer__panel {
+  display: none;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
+}
+
+.drawer__panel.is-active {
+  display: flex;
+}
+
+.drawer__panel--root,
+.drawer__panel--submenu {
   overflow-y: auto;
 }
 
-.drawer__menu ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.drawer__panel-header {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+  margin-bottom: calc(var(--space) * 4);
 }
 
-.drawer__menu a {
-  display: block;
+.drawer__panel-title {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: var(--fs-4);
+  font-weight: 600;
+  color: var(--on-brand);
+  text-align: center;
+}
+
+.drawer__back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--on-brand);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+
+.drawer__back:hover,
+.drawer__back:focus-visible {
+  background-color: var(--brand);
+  color: var(--on-brand);
+  outline: none;
+}
+
+.drawer__back svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__list,
+.drawer__submenu-list,
+.drawer__grandchildren {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.drawer__list {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item--language {
+  margin-top: auto;
+  padding-top: calc(var(--space) * 4);
+  border-top: var(--border-w) solid var(--border);
+  flex-direction: column;
+  align-items: stretch;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__link {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: calc(var(--space) * 1.5);
   padding: calc(var(--space) * 3) calc(var(--space) * 2);
   font-size: var(--fs-2);
+  font-weight: 600;
   color: var(--on-brand);
   border-radius: var(--radius);
   text-decoration: none;
-  transition: background-color var(--t-normal) var(--ease);
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
 }
 
-.drawer__menu a:hover,
-.drawer__menu a.is-active {
+.drawer__link:hover,
+.drawer__link.is-active {
   background-color: var(--brand);
   color: var(--on-brand);
 }
 
-[data-theme="dark"] .drawer__menu a:hover,
-[data-theme="dark"] .drawer__menu a.is-active {
+[data-theme="dark"] .drawer__link:hover,
+[data-theme="dark"] .drawer__link.is-active {
   background-color: var(--brand);
   color: var(--on-brand);
 }
 
-/* 移动端子菜单样式 */
-.drawer__menu .submenu {
-  padding-left: calc(var(--space) * 4);
-  margin-top: calc(var(--space) * -1);
-}
-
-.drawer__menu .submenu a {
-  font-size: var(--fs-1);
-  padding-block: calc(var(--space) * 2);
-}
-
-.drawer__footer {
-  padding-top: calc(var(--space) * 4);
-  margin-top: auto;
-  border-top: var(--border-w) solid var(--border);
-}
-
-.drawer__footer .lang-switcher__button {
-  width: 100%;
+.drawer__chevron {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--on-brand);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+
+.drawer__chevron:hover,
+.drawer__chevron:focus-visible {
+  background-color: var(--brand);
+  color: var(--on-brand);
+  outline: none;
+}
+
+.drawer__chevron svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__submenu-list {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__submenu-item {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__grandchildren {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+  padding-left: calc(var(--space) * 4);
+}
+
+.drawer__language {
+  width: 100%;
+}
+
+.drawer__lang-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--space) * 1.5);
+  padding: calc(var(--space) * 2.5) calc(var(--space) * 2);
+  font-size: var(--fs-2);
+  color: var(--on-brand);
+  background: transparent;
+  border: var(--border-w) solid unquote("rgb(from var(--on-brand) r g b / 25%)");
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease), border-color var(--t-normal) var(--ease);
+}
+
+.drawer__lang-toggle svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__lang-toggle:hover,
+.drawer__lang-toggle:focus-visible {
+  background-color: var(--brand);
+  color: var(--on-brand);
+  border-color: transparent;
+  outline: none;
+}
+
+.drawer__lang-options {
+  border-radius: var(--radius);
+  border: var(--border-w) solid unquote("rgb(from var(--on-brand) r g b / 20%)");
+  background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
+  padding: calc(var(--space) * 2);
+  display: none;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__lang-options.is-open {
+  display: flex;
+}
+
+.drawer__lang-options ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__lang-options a {
+  display: block;
+  font-size: var(--fs-2);
+  color: var(--on-brand);
+  text-decoration: none;
+  padding: calc(var(--space) * 1.5) calc(var(--space) * 2);
+  border-radius: var(--radius);
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
+}
+
+.drawer__lang-options a:hover,
+.drawer__lang-options a.is-active {
+  background-color: var(--brand);
+  color: var(--on-brand);
 }
 
 /*
@@ -520,12 +690,25 @@ body[data-drawer-open='true'] {
         */
 @media (max-width: 1023.98px) {
 
-  .navbar__menu,
-  .navbar__actions .lang-switcher {
+  .navbar__menu {
+    display: none;
+  }
+
+  .lang-switcher--desktop {
     display: none;
   }
 
   .navbar__toggler {
     display: flex;
   }
+}
+
+.drawer__submenu-item > .drawer__link {
+  font-weight: 500;
+}
+
+.drawer__grandchildren .drawer__link {
+  font-size: var(--fs-1);
+  font-weight: 500;
+  padding-block: calc(var(--space) * 2);
 }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,19 @@
+{{ if hugo.IsMultilingual }}
+  {{ $currentPage := . }}
+  {{ $languageOptions := slice $currentPage }}
+  {{ range .Translations }}
+    {{ $languageOptions = $languageOptions | append . }}
+  {{ end }}
+  {{ range .Site.Home.AllTranslations }}
+    {{ $lang := .Language.Lang }}
+    {{ if not (first 1 (where $languageOptions "Language.Lang" $lang)) }}
+      {{ $languageOptions = $languageOptions | append . }}
+    {{ end }}
+  {{ end }}
+  {{ $languageOptions = sort $languageOptions "Language.Weight" }}
+  {{ $.Scratch.Set "languageOptions" $languageOptions }}
+{{ end }}
+
 <header class="site-header" id="site-header">
   <nav class="navbar">
 
@@ -78,28 +94,22 @@
 
     <div class="navbar__actions">
       {{ if hugo.IsMultilingual }}
-      <div class="lang-switcher">
-        <button class="lang-switcher__button">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5"
-            stroke="currentColor" aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path d="M2 12h20"></path>
-            <path d="M12 2a15.75 15.75 0 0 1 0 20"></path>
-            <path d="M12 2a15.75 15.75 0 0 0 0 20"></path>
-          </svg>
-          <span>{{ .Site.Language.LanguageName }}</span>
-        </button>
-        <div class="lang-switcher__dropdown">
-          {{ range .Site.Home.AllTranslations }}
-          {{ if ne .Language.Lang $.Site.Language.Lang }}
-          <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
-          {{ end }}
-          {{ end }}
+        {{ $languageOptions := $.Scratch.Get "languageOptions" }}
+        {{ $languageLabel := i18n "language_switcher_label" | default "选择语言" }}
+        {{ $currentLang := $.Language.Lang }}
+        <div class="lang-switcher lang-switcher--desktop" data-lang-switcher>
+          <label class="sr-only" for="lang-switcher-desktop">{{ $languageLabel }}</label>
+          <select id="lang-switcher-desktop" class="lang-switcher__select">
+            {{ range $languageOptions }}
+              <option value="{{ .RelPermalink }}" {{ if eq .Language.Lang $currentLang }}selected{{ end }}>
+                {{ .Language.LanguageName }}
+              </option>
+            {{ end }}
+          </select>
         </div>
-      </div>
       {{ end }}
 
-      <button class="navbar__toggler" id="drawer-toggler" aria-label="Open menu">
+      <button class="navbar__toggler" id="drawer-toggler" aria-label="打开菜单" aria-expanded="false" data-open-label="打开菜单" data-close-label="关闭菜单">
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
@@ -114,35 +124,89 @@
     <span class="sr-only">Menu</span>
   </div>
 
-  <nav class="drawer__menu" aria-label="Mobile navigation">
+  <nav class="drawer__menu" aria-label="Mobile navigation" data-drawer-menu>
     {{ $current := . }}
-    <ul>
-      {{ range .Site.Menus.main }}
-      {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
-          {{ range .Children }}
-          {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-          <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
-          {{ end }}
-        </ul>
+    {{ $submenuPanels := slice }}
+    <div class="drawer__panel drawer__panel--root is-active" data-drawer-panel="drawer-root">
+      <ul class="drawer__list">
+        {{ range .Site.Menus.main }}
+        {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+        {{ $panelKey := .Identifier }}
+        {{ if not $panelKey }}
+          {{ $panelKey = anchorize .Name }}
         {{ end }}
-      </li>
-      {{ end }}
-    </ul>
+        {{ $panelID := printf "drawer-panel-%s" $panelKey }}
+        {{ if .HasChildren }}
+          {{ $submenuPanels = $submenuPanels | append (dict "panelID" $panelID "menu" .) }}
+        {{ end }}
+        <li class="drawer__item{{ if .HasChildren }} has-children{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $active }}is-active{{ end }}">{{ .Name }}</a>
+          {{ if .HasChildren }}
+          <button type="button" class="drawer__chevron" data-submenu-target="{{ $panelID }}" aria-label="浏览{{ .Name }}子菜单">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M9.17 5.47a1 1 0 0 1 1.41.06l5 5.5a1 1 0 0 1 0 1.34l-5 5.5a1 1 0 1 1-1.48-1.34L13.59 12 9.1 6.81a1 1 0 0 1 .07-1.34Z" />
+            </svg>
+          </button>
+          {{ end }}
+        </li>
+        {{ end }}
+        {{ if and (hugo.IsMultilingual) ($.Scratch.Get "languageOptions") }}
+        {{ $languageOptions := $.Scratch.Get "languageOptions" }}
+        {{ $languageLabel := i18n "language_switcher_label" | default "选择语言" }}
+        {{ $currentLang := $.Language.Lang }}
+        <li class="drawer__item drawer__item--language">
+          <div class="drawer__language" data-language-menu>
+            <button type="button" class="drawer__lang-toggle" data-lang-toggle aria-expanded="false" aria-controls="drawer-language-options">
+              <span>{{ $languageLabel }}</span>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M5.47 9.22a1 1 0 0 1 1.41 0L12 14.34l5.12-5.12a1 1 0 1 1 1.41 1.42l-5.83 5.83a1.5 1.5 0 0 1-2.12 0L5.47 10.64a1 1 0 0 1 0-1.42Z" />
+              </svg>
+            </button>
+            <div class="drawer__lang-options" id="drawer-language-options" hidden>
+              <ul>
+                {{ range $languageOptions }}
+                <li>
+                  <a href="{{ .RelPermalink }}" class="{{ if eq .Language.Lang $currentLang }}is-active{{ end }}" {{ if eq .Language.Lang $currentLang }}aria-current="true"{{ end }}>
+                    {{ .Language.LanguageName }}
+                  </a>
+                </li>
+                {{ end }}
+              </ul>
+            </div>
+          </div>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ range $submenuPanels }}
+    {{ $menu := .menu }}
+    <div class="drawer__panel drawer__panel--submenu" data-drawer-panel="{{ .panelID }}" hidden>
+      <div class="drawer__panel-header">
+        <button type="button" class="drawer__back" data-panel-back aria-label="返回一级菜单">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M15.53 5.47a.75.75 0 0 1 0 1.06L10.06 12l5.47 5.47a.75.75 0 0 1-1.06 1.06l-6-6a.75.75 0 0 1 0-1.06l6-6a.75.75 0 0 1 1.06 0Z" />
+          </svg>
+        </button>
+        <h2 class="drawer__panel-title">{{ $menu.Name }}</h2>
+      </div>
+      <ul class="drawer__submenu-list">
+        {{ range $menu.Children }}
+        <li class="drawer__submenu-item{{ if .HasChildren }} has-grandchildren{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="drawer__link">{{ .Name }}</a>
+          {{ if .HasChildren }}
+          <ul class="drawer__grandchildren">
+            {{ range .Children }}
+            <li><a href="{{ .URL | relLangURL }}" class="drawer__link">{{ .Name }}</a></li>
+            {{ end }}
+          </ul>
+          {{ end }}
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
   </nav>
 
-  {{ if hugo.IsMultilingual }}
-  <div class="drawer__footer">
-    <div class="lang-switcher">
-      {{ range .Site.Home.AllTranslations }}
-      <a class="lang-switcher__button" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
-      {{ end }}
-    </div>
-  </div>
-  {{ end }}
 </aside>
 
 <script>
@@ -209,40 +273,129 @@
       handleSmartHeader();
     }
 
-    // --- 2. 抽屉 (Drawer) 逻辑 (保持不变) ---
+    // --- 2. 抽屉 (Drawer) 逻辑 ---
+    const drawer = document.getElementById('drawer');
     const drawerToggler = document.getElementById('drawer-toggler');
     const drawerOverlay = document.getElementById('drawer-overlay');
+    const drawerMenu = drawer ? drawer.querySelector('[data-drawer-menu]') : null;
+    const rootPanelId = 'drawer-root';
 
-    const openDrawer = () => {
-      body.setAttribute('data-drawer-open', 'true');
-      if (drawerToggler) drawerToggler.classList.add('open');
-    };
-    const closeDrawer = () => {
-      body.setAttribute('data-drawer-open', 'false');
-      if (drawerToggler) drawerToggler.classList.remove('open');
-    };
-
-    if (drawerToggler) {
-      drawerToggler.addEventListener('click', () => {
-        const isOpen = body.getAttribute('data-drawer-open') === 'true';
-        if (isOpen) {
-          // 关闭抽屉
-          closeDrawer();
-        } else {
-          // 打开抽屉
-          openDrawer();
+    const panelMap = new Map();
+    if (drawerMenu) {
+      drawerMenu.querySelectorAll('[data-drawer-panel]').forEach((panel) => {
+        const id = panel.getAttribute('data-drawer-panel');
+        if (id) {
+          panelMap.set(id, panel);
         }
       });
     }
 
+    const resetLanguageMenu = () => {
+      if (!drawerMenu) return;
+      const langContainer = drawerMenu.querySelector('[data-language-menu]');
+      if (!langContainer) return;
+      const langToggle = langContainer.querySelector('[data-lang-toggle]');
+      const langPanel = langContainer.querySelector('.drawer__lang-options');
+      if (langToggle && langPanel) {
+        langToggle.setAttribute('aria-expanded', 'false');
+        langPanel.hidden = true;
+        langPanel.classList.remove('is-open');
+      }
+    };
+
+    const activatePanel = (panelId) => {
+      const targetId = panelMap.has(panelId) ? panelId : rootPanelId;
+      panelMap.forEach((panel, id) => {
+        const isActive = id === targetId;
+        panel.classList.toggle('is-active', isActive);
+        panel.toggleAttribute('hidden', !isActive);
+      });
+      if (drawer) {
+        drawer.setAttribute('data-active-panel', targetId);
+      }
+      if (targetId !== rootPanelId) {
+        resetLanguageMenu();
+      }
+    };
+
+    const setDrawerState = (isOpen) => {
+      body.setAttribute('data-drawer-open', isOpen ? 'true' : 'false');
+      if (drawerToggler) {
+        drawerToggler.classList.toggle('open', isOpen);
+        drawerToggler.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        const openLabel = drawerToggler.getAttribute('data-open-label') || '打开菜单';
+        const closeLabel = drawerToggler.getAttribute('data-close-label') || '关闭菜单';
+        drawerToggler.setAttribute('aria-label', isOpen ? closeLabel : openLabel);
+      }
+
+      activatePanel(rootPanelId);
+
+      if (!isOpen) {
+        resetLanguageMenu();
+      }
+    };
+
+    const isDrawerOpen = () => body.getAttribute('data-drawer-open') === 'true';
+
+    if (drawerToggler) {
+      drawerToggler.addEventListener('click', () => {
+        setDrawerState(!isDrawerOpen());
+      });
+    }
+
     if (drawerOverlay) {
-      drawerOverlay.addEventListener('click', closeDrawer);
+      drawerOverlay.addEventListener('click', () => setDrawerState(false));
     }
 
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && body.getAttribute('data-drawer-open') === 'true') {
-        closeDrawer();
+      if (event.key === 'Escape' && isDrawerOpen()) {
+        setDrawerState(false);
       }
+    });
+
+    if (drawerMenu) {
+      drawerMenu.addEventListener('click', (event) => {
+        const submenuTrigger = event.target.closest('[data-submenu-target]');
+        if (submenuTrigger) {
+          event.preventDefault();
+          const target = submenuTrigger.getAttribute('data-submenu-target');
+          activatePanel(target);
+          return;
+        }
+
+        const backTrigger = event.target.closest('[data-panel-back]');
+        if (backTrigger) {
+          event.preventDefault();
+          activatePanel(rootPanelId);
+          return;
+        }
+
+        const langToggle = event.target.closest('[data-lang-toggle]');
+        if (langToggle) {
+          event.preventDefault();
+          const controls = langToggle.getAttribute('aria-controls');
+          const langPanel = controls ? document.getElementById(controls) : null;
+          if (!langPanel) return;
+          const expanded = langToggle.getAttribute('aria-expanded') === 'true';
+          const nextState = !expanded;
+          langToggle.setAttribute('aria-expanded', nextState ? 'true' : 'false');
+          langPanel.hidden = !nextState;
+          langPanel.classList.toggle('is-open', nextState);
+          return;
+        }
+      });
+    }
+
+    activatePanel(rootPanelId);
+
+    const langSwitchers = document.querySelectorAll('[data-lang-switcher] .lang-switcher__select');
+    langSwitchers.forEach((select) => {
+      select.addEventListener('change', () => {
+        const target = select.value;
+        if (target) {
+          window.location.href = target;
+        }
+      });
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- rebuild the mobile drawer markup so level-one items open dedicated sub-panels and the language switcher sits at the bottom of the root view
- add drawer scripting that manages panel transitions, back navigation, and language dropdown behavior while keeping the toggler state in sync
- restyle the drawer to support the new full-width slide-down presentation with larger hit areas, panel headers, and nested list spacing

## Testing
- hugo --minify *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e552f19a64832cb7f9d45bd3f96438