### PR TITLE
Refine mobile drawer navigation

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -425,18 +425,18 @@ body[data-drawer-open="true"] #site-header {
 .drawer {
   position: fixed;
   top: 0;
+  left: 0;
   right: 0;
-  bottom: 0;
-  width: 80%;
-  max-width: 320px;
   background-color: var(--brand);
   background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
   z-index: var(--z-modal);
-  transform: translateX(100%);
+  transform: translateY(-100%);
   transition: transform var(--t-normal) var(--ease);
   display: flex;
   flex-direction: column;
-  padding: calc(var(--space) * 4);
+  padding: calc(var(--space) * 4) calc(var(--space) * 3) calc(var(--space) * 6);
+  max-height: 100vh;
+  overflow: hidden;
 }
 
 body[data-drawer-open='true'] .drawer-overlay {
@@ -445,7 +445,7 @@ body[data-drawer-open='true'] .drawer-overlay {
 }
 
 body[data-drawer-open='true'] .drawer {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 body[data-drawer-open='true'] {
@@ -454,14 +454,49 @@ body[data-drawer-open='true'] {
 
 .drawer__header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: calc(var(--space) * 6);
+  gap: calc(var(--space) * 2);
+  margin-bottom: calc(var(--space) * 4);
 }
 
+.drawer__back {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--space));
+  border: none;
+  background: none;
+  color: var(--on-brand);
+  font-size: var(--fs-2);
+  font-weight: 500;
+  padding: calc(var(--space));
+  border-radius: var(--radius);
+  cursor: pointer;
+}
 
-.drawer__menu {
+.drawer__back:hover,
+.drawer__back:focus-visible {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
+  outline: none;
+}
+
+.drawer__back:focus-visible {
+  box-shadow: 0 0 0 2px unquote("rgb(from var(--on-brand) r g b / 35%)");
+}
+
+.drawer__back svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__title {
+  color: var(--on-brand);
+  font-size: var(--fs-3);
+  font-weight: 600;
   flex-grow: 1;
+}
+
+.drawer__body {
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -471,9 +506,26 @@ body[data-drawer-open='true'] {
   margin: 0;
 }
 
-.drawer__menu a {
+.drawer__list {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space));
+}
+
+.drawer__item {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space));
+}
+
+.drawer__item.has-children {
+  justify-content: space-between;
+}
+
+.drawer__link {
+  flex: 1;
   display: block;
-  padding: calc(var(--space) * 3) calc(var(--space) * 2);
+  padding: calc(var(--space) * 2.5) calc(var(--space) * 2);
   font-size: var(--fs-2);
   color: var(--on-brand);
   border-radius: var(--radius);
@@ -481,27 +533,69 @@ body[data-drawer-open='true'] {
   transition: background-color var(--t-normal) var(--ease);
 }
 
-.drawer__menu a:hover,
-.drawer__menu a.is-active {
-  background-color: var(--brand);
-  color: var(--on-brand);
+.drawer__list--level2 .drawer__link {
+  font-size: var(--fs-2);
 }
 
-[data-theme="dark"] .drawer__menu a:hover,
-[data-theme="dark"] .drawer__menu a.is-active {
-  background-color: var(--brand);
-  color: var(--on-brand);
-}
-
-/* 移动端子菜单样式 */
-.drawer__menu .submenu {
-  padding-left: calc(var(--space) * 4);
-  margin-top: calc(var(--space) * -1);
-}
-
-.drawer__menu .submenu a {
+.drawer__list--level3 .drawer__link {
   font-size: var(--fs-1);
-  padding-block: calc(var(--space) * 2);
+  padding-block: calc(var(--space) * 1.5);
+  padding-left: calc(var(--space) * 3);
+}
+
+.drawer__link:hover,
+.drawer__link:focus-visible,
+.drawer__link.is-active {
+  background-color: var(--brand);
+  color: var(--on-brand);
+}
+
+.drawer__link:focus-visible {
+  outline: none;
+}
+
+.drawer__arrow {
+  border: none;
+  background: none;
+  color: var(--on-brand);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--space) * 1.5);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color var(--t-normal) var(--ease);
+}
+
+.drawer__arrow:hover {
+  background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
+}
+
+.drawer__arrow svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__arrow:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px unquote("rgb(from var(--on-brand) r g b / 35%)");
+}
+
+.drawer__submenu {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__list--level2 {
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__list--level3 {
+  gap: calc(var(--space));
+  margin-top: calc(var(--space));
+  padding-left: calc(var(--space) * 2);
+  border-left: var(--border-w) solid unquote("rgb(from var(--on-brand) r g b / 20%)");
 }
 
 .drawer__footer {

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -23,4 +23,7 @@ posted_by = "发布者"
 read_more = "阅读全文"
 submit = "发送信息"
 tags = "标签"
+mobile_menu_title = "Menu"
+mobile_menu_back = "Back to main menu"
+mobile_menu_open_submenu = "View submenu"
 

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -25,4 +25,7 @@ read_more = "阅读全文"
 submit = "发送信息"
 social_title = "社交媒体"
 tags = "标签"
+mobile_menu_title = "菜单"
+mobile_menu_back = "返回一级菜单"
+mobile_menu_open_submenu = "查看子菜单"
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -111,31 +111,71 @@
 <div class="drawer-overlay" id="drawer-overlay"></div>
 <aside class="drawer" id="drawer">
   <div class="drawer__header">
-    <span class="sr-only">Menu</span>
+    {{ $backLabel := i18n "mobile_menu_back" | default "Back" }}
+    <button type="button" class="drawer__back" id="drawer-back" aria-label="{{ $backLabel }}" hidden>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke="currentColor"
+        aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M15 5l-7 7 7 7" />
+      </svg>
+      <span>{{ $backLabel }}</span>
+    </button>
+    {{ $menuTitle := i18n "mobile_menu_title" | default "Menu" }}
+    <span class="drawer__title" id="drawer-title" data-default-title="{{ $menuTitle }}">{{ $menuTitle }}</span>
   </div>
 
-  <nav class="drawer__menu" aria-label="Mobile navigation">
-    {{ $current := . }}
-    <ul>
+  <div class="drawer__body">
+    <nav class="drawer__menu" aria-label="Mobile navigation">
+      {{ $current := . }}
+      <ul class="drawer__list drawer__list--level1" data-drawer-primary>
+        {{ range .Site.Menus.main }}
+        {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+        {{ $menuKey := printf "submenu-%s" (anchorize (or .Identifier .Name)) }}
+        <li class="drawer__item {{ if .HasChildren }}has-children{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $active }}is-active{{ end }}">{{ .Name }}</a>
+          {{ if .HasChildren }}
+          {{ $submenuLabel := i18n "mobile_menu_open_submenu" | default "View submenu" }}
+          <button class="drawer__arrow" type="button" data-submenu-target="{{ $menuKey }}"
+            aria-label="{{ $submenuLabel }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5"
+              stroke="currentColor" aria-hidden="true" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+          {{ end }}
+        </li>
+        {{ end }}
+      </ul>
+
       {{ range .Site.Menus.main }}
-      {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
+      {{ if .HasChildren }}
+      {{ $menuKey := printf "submenu-%s" (anchorize (or .Identifier .Name)) }}
+      <div class="drawer__submenu" data-drawer-submenu="{{ $menuKey }}" data-parent-name="{{ .Name }}" hidden>
+        <ul class="drawer__list drawer__list--level2">
           {{ range .Children }}
           {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-          <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
+          <li class="drawer__item {{ if .HasChildren }}has-children{{ end }}">
+            <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $childActive }}is-active{{ end }}">{{ .Name }}</a>
+            {{ if .HasChildren }}
+            <ul class="drawer__list drawer__list--level3">
+              {{ range .Children }}
+              {{ $grandActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+              <li class="drawer__item">
+                <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $grandActive }}is-active{{ end }}">{{ .Name }}</a>
+              </li>
+              {{ end }}
+            </ul>
+            {{ end }}
+          </li>
           {{ end }}
         </ul>
-        {{ end }}
-      </li>
+      </div>
       {{ end }}
-    </ul>
-  </nav>
+      {{ end }}
+    </nav>
+  </div>
 
   {{ if hugo.IsMultilingual }}
-  <div class="drawer__footer">
+  <div class="drawer__footer" data-drawer-langs>
     <div class="lang-switcher">
       {{ range .Site.Home.AllTranslations }}
       <a class="lang-switcher__button" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
@@ -212,14 +252,60 @@
     // --- 2. 抽屉 (Drawer) 逻辑 (保持不变) ---
     const drawerToggler = document.getElementById('drawer-toggler');
     const drawerOverlay = document.getElementById('drawer-overlay');
+    const drawer = document.getElementById('drawer');
+    const drawerMenu = drawer ? drawer.querySelector('.drawer__menu') : null;
+    const drawerPrimary = drawer ? drawer.querySelector('[data-drawer-primary]') : null;
+    const drawerSubmenus = drawer ? Array.from(drawer.querySelectorAll('[data-drawer-submenu]')) : [];
+    const drawerBack = document.getElementById('drawer-back');
+    const drawerTitle = document.getElementById('drawer-title');
+    const drawerLangs = drawer ? drawer.querySelector('[data-drawer-langs]') : null;
+    const defaultDrawerTitle = drawerTitle ? drawerTitle.dataset.defaultTitle || drawerTitle.textContent : '';
+
+    if (drawerToggler) {
+      drawerToggler.setAttribute('aria-expanded', 'false');
+    }
+
+    let activeSubmenu = null;
+
+    const showPrimaryView = () => {
+      if (drawerPrimary) drawerPrimary.removeAttribute('hidden');
+      drawerSubmenus.forEach((submenu) => submenu.setAttribute('hidden', ''));
+      activeSubmenu = null;
+      if (drawerBack) drawerBack.hidden = true;
+      if (drawerLangs) drawerLangs.removeAttribute('hidden');
+      if (drawerTitle && defaultDrawerTitle) drawerTitle.textContent = defaultDrawerTitle;
+      if (drawer) drawer.classList.remove('drawer--submenu');
+    };
+
+    const showSubmenu = (submenu) => {
+      if (!submenu) return;
+      if (drawerPrimary) drawerPrimary.setAttribute('hidden', '');
+      drawerSubmenus.forEach((item) => {
+        if (item !== submenu) item.setAttribute('hidden', '');
+      });
+      submenu.removeAttribute('hidden');
+      activeSubmenu = submenu;
+      if (drawerBack) drawerBack.hidden = false;
+      if (drawerLangs) drawerLangs.setAttribute('hidden', '');
+      if (drawerTitle) drawerTitle.textContent = submenu.dataset.parentName || defaultDrawerTitle;
+      if (drawer) drawer.classList.add('drawer--submenu');
+    };
 
     const openDrawer = () => {
+      showPrimaryView();
       body.setAttribute('data-drawer-open', 'true');
-      if (drawerToggler) drawerToggler.classList.add('open');
+      if (drawerToggler) {
+        drawerToggler.classList.add('open');
+        drawerToggler.setAttribute('aria-expanded', 'true');
+      }
     };
     const closeDrawer = () => {
+      showPrimaryView();
       body.setAttribute('data-drawer-open', 'false');
-      if (drawerToggler) drawerToggler.classList.remove('open');
+      if (drawerToggler) {
+        drawerToggler.classList.remove('open');
+        drawerToggler.setAttribute('aria-expanded', 'false');
+      }
     };
 
     if (drawerToggler) {
@@ -237,6 +323,26 @@
 
     if (drawerOverlay) {
       drawerOverlay.addEventListener('click', closeDrawer);
+    }
+
+    if (drawerBack) {
+      drawerBack.addEventListener('click', () => {
+        if (activeSubmenu) {
+          showPrimaryView();
+        }
+      });
+    }
+
+    if (drawerMenu) {
+      drawerMenu.addEventListener('click', (event) => {
+        const arrowButton = event.target.closest('[data-submenu-target]');
+        if (!arrowButton) return;
+        event.preventDefault();
+        const targetId = arrowButton.getAttribute('data-submenu-target');
+        if (!targetId) return;
+        const submenu = drawerSubmenus.find((item) => item.dataset.drawerSubmenu === targetId);
+        showSubmenu(submenu);
+      });
     }
 
     document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
## Summary
- rebuild the mobile drawer markup to support first-level navigation with submenu toggles, a back control, and language switching scoped to the root view
- add JavaScript state management so submenu transitions replace the list content, update titles, and reset when closing the drawer
- restyle the drawer to slide in from the top with updated spacing, focus, and button treatments for the new controls

## Testing
- `hugo` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b7f509f4832cac5c94e7b712192f