### PR TITLE
Introduce selectable navigation skins

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -93,9 +93,16 @@ body.header-hidden {
   white-space: nowrap;       /* 强制链接不换行 */
 }
 
-.navbar__menu a:hover {
+.navbar__menu a:hover,
+.navbar__menu a:focus-visible {
   background-color: unquote("rgb(from var(--on-brand) r g b / 15%)");
   text-decoration: none;
+}
+
+.site-header :is(a, button):focus-visible,
+.drawer :is(a, button):focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
 }
 
 .navbar__menu a.is-active {
@@ -259,7 +266,9 @@ body.header-hidden {
 }
 
 .dropdown-menu a:hover,
-.mega-menu__list a:hover {
+.dropdown-menu a:focus-visible,
+.mega-menu__list a:hover,
+.mega-menu__list a:focus-visible {
   background-color: unquote("rgb(from var(--brand) r g b / 12%)");
   color: var(--brand);
   text-decoration: none;
@@ -422,21 +431,24 @@ body[data-drawer-open="true"] #site-header {
   transition: opacity var(--t-normal) var(--ease), visibility var(--t-normal) var(--ease);
 }
 
+
 .drawer {
   position: fixed;
   top: 0;
+  left: 0;
   right: 0;
-  bottom: 0;
-  width: 80%;
-  max-width: 320px;
+  height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
   background-color: var(--brand);
   background-color: unquote("rgb(from var(--brand) r g b / var(--layer-alpha))");
   z-index: var(--z-modal);
-  transform: translateX(100%);
+  transform: translateY(-100%);
   transition: transform var(--t-normal) var(--ease);
   display: flex;
   flex-direction: column;
   padding: calc(var(--space) * 4);
+  box-shadow: 0 calc(var(--space) * 2) calc(var(--space) * 8) rgba(0, 0, 0, 0.25);
 }
 
 body[data-drawer-open='true'] .drawer-overlay {
@@ -445,7 +457,7 @@ body[data-drawer-open='true'] .drawer-overlay {
 }
 
 body[data-drawer-open='true'] .drawer {
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 body[data-drawer-open='true'] {
@@ -454,65 +466,723 @@ body[data-drawer-open='true'] {
 
 .drawer__header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: calc(var(--space) * 6);
+  gap: calc(var(--space) * 2);
+  margin-bottom: calc(var(--space) * 4);
 }
 
+.drawer__back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: none;
+  color: var(--on-brand);
+  cursor: pointer;
+  padding: 0;
+}
+
+.drawer__back svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__title {
+  font-size: var(--fs-3);
+  font-weight: 600;
+  color: var(--on-brand);
+}
 
 .drawer__menu {
-  flex-grow: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.drawer__panel { 
+  display: none;
+  flex-direction: column;
+  gap: calc(var(--space) * 4);
+  flex: 1;
+}
+
+.drawer__panel.is-active {
+  display: flex;
   overflow-y: auto;
 }
 
-.drawer__menu ul {
-  list-style: none;
+.drawer__panel-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: none;
+  color: var(--on-brand);
   padding: 0;
-  margin: 0;
+  margin-bottom: calc(var(--space) * 2);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: color var(--t-normal) var(--ease), background-color var(--t-normal) var(--ease);
 }
 
-.drawer__menu a {
+.drawer__panel-back:hover,
+.drawer__panel-back:focus-visible {
+  color: var(--on-brand-strong, var(--on-brand));
+  background-color: unquote("rgb(from var(--on-brand) r g b / 18%)");
+}
+
+.drawer__panel-back svg {
+  width: 20px;
+  height: 20px;
+}
+
+.drawer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item--root {
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__item--root .drawer__link {
+  flex: 1;
+}
+
+.drawer__item--second {
+  flex-direction: column;
+  align-items: stretch;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__link,
+.drawer__sublink {
+  display: block;
+  width: 100%;
+  padding: calc(var(--space) * 3) calc(var(--space) * 2);
+  font-size: var(--fs-2);
+  color: var(--on-brand);
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
+}
+
+.drawer__sublink {
+  font-size: var(--fs-1);
+  padding-block: calc(var(--space) * 2);
+}
+
+.drawer__link:hover,
+.drawer__link:focus-visible,
+.drawer__link.is-active,
+.drawer__sublink:hover,
+.drawer__sublink:focus-visible,
+.drawer__sublink.is-active {
+  background-color: var(--brand);
+  color: var(--on-brand);
+}
+
+[data-theme="dark"] .drawer__link:hover,
+[data-theme="dark"] .drawer__link.is-active,
+[data-theme="dark"] .drawer__sublink:hover,
+[data-theme="dark"] .drawer__sublink.is-active {
+  background-color: var(--brand);
+  color: var(--on-brand);
+}
+
+.drawer__arrow {
+  border: none;
+  background: none;
+  color: var(--on-brand);
+  cursor: pointer;
+  padding: calc(var(--space) * 1.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.drawer__arrow svg {
+  width: 18px;
+  height: 18px;
+}
+
+.drawer__sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 calc(var(--space) * 4);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 1.5);
+}
+
+.drawer__languages {
+  border-top: var(--border-w) solid var(--border);
+  padding-top: calc(var(--space) * 4);
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer--submenu .drawer__languages {
+  display: none;
+}
+
+.drawer__panel--products .drawer__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: calc(var(--space) * 4);
+}
+
+.drawer__panel--products .drawer__item {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.drawer__panel--products .drawer__sublist {
+  padding: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: calc(var(--space) * 2);
+}
+
+@media (max-width: 599px) {
+  .drawer__panel--products .drawer__list,
+  .drawer__panel--products .drawer__sublist {
+    grid-template-columns: 1fr;
+  }
+}
+
+.drawer__languages-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--space) * 2);
+  width: 100%;
+  border: none;
+  background: none;
+  color: var(--on-brand);
+  font-size: var(--fs-2);
+  font-weight: 500;
+  padding: calc(var(--space) * 2) 0;
+  cursor: pointer;
+}
+
+.drawer__languages-toggle svg {
+  width: 18px;
+  height: 18px;
+  transition: transform var(--t-normal) var(--ease);
+}
+
+.drawer__languages.is-open .drawer__languages-toggle svg {
+  transform: rotate(180deg);
+}
+
+.drawer__languages-panel {
+  display: none;
+}
+
+.drawer__languages.is-open .drawer__languages-panel {
+  display: block;
+}
+
+.drawer__languages-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__languages-list a {
   display: block;
   padding: calc(var(--space) * 3) calc(var(--space) * 2);
   font-size: var(--fs-2);
   color: var(--on-brand);
   border-radius: var(--radius);
   text-decoration: none;
-  transition: background-color var(--t-normal) var(--ease);
+  transition: background-color var(--t-normal) var(--ease), color var(--t-normal) var(--ease);
 }
 
-.drawer__menu a:hover,
-.drawer__menu a.is-active {
+.drawer__languages-list a:hover,
+.drawer__languages-list a:focus-visible {
   background-color: var(--brand);
-  color: var(--on-brand);
 }
 
-[data-theme="dark"] .drawer__menu a:hover,
-[data-theme="dark"] .drawer__menu a.is-active {
-  background-color: var(--brand);
-  color: var(--on-brand);
+/*
+        * 导航主题（Skins）
+        */
+
+.nav-theme {
+  transition: background-color var(--t-normal) var(--ease),
+    border-color var(--t-normal) var(--ease),
+    box-shadow var(--t-normal) var(--ease),
+    transform var(--t-normal) var(--ease);
 }
 
-/* 移动端子菜单样式 */
-.drawer__menu .submenu {
-  padding-left: calc(var(--space) * 4);
-  margin-top: calc(var(--space) * -1);
+// Variant 1 · Classic: glassy brand bar with luminous drawer
+.nav-theme--classic {
+  &.site-header {
+    background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 55%);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+    color: var(--on-brand);
+  }
+
+  &.site-header .navbar__menu a {
+    color: var(--on-brand);
+  }
+
+  &.site-header .navbar__actions,
+  &.site-header .lang-switcher__button,
+  &.site-header .navbar__toggler {
+    color: var(--on-brand);
+  }
+
+  &.site-header .dropdown-menu,
+  &.site-header .mega-menu {
+    background-color: unquote("rgb(from var(--surface) r g b / 96%)");
+  }
+
+  &.drawer-overlay {
+    background: rgba(12, 22, 36, 0.6);
+  }
+
+  &.drawer {
+    background: linear-gradient(180deg,
+        unquote("rgb(from var(--brand) r g b / var(--layer-alpha))") 0%,
+        rgba(8, 17, 28, 0.92) 100%);
+    color: var(--on-brand);
+  }
+
+  &.drawer :is(.drawer__title, .drawer__link, .drawer__sublink, .drawer__languages-toggle, .drawer__languages-list a) {
+    color: var(--on-brand);
+  }
+
+  &.drawer :is(.drawer__link:hover, .drawer__link:focus-visible, .drawer__sublink:hover, .drawer__sublink:focus-visible,
+      .drawer__languages-list a:hover, .drawer__languages-list a:focus-visible) {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--on-brand);
+  }
 }
 
-.drawer__menu .submenu a {
-  font-size: var(--fs-1);
-  padding-block: calc(var(--space) * 2);
+// Variant 2 · Minimal: light surface with understated pill highlights
+.nav-theme--minimal {
+  &.site-header {
+    background: var(--surface);
+    background: linear-gradient(180deg,
+        color-mix(in srgb, var(--surface) 92%, white 8%),
+        color-mix(in srgb, var(--surface) 98%, white 2%));
+    color: var(--on-surface);
+    border-bottom: var(--border-w) solid unquote("rgb(from var(--on-surface) r g b / 12%)");
+    box-shadow: 0 18px 40px unquote("rgb(from var(--on-surface) r g b / 14%)");
+  }
+
+  &.site-header .navbar__menu > ul {
+    gap: calc(var(--space) * 1.5);
+  }
+
+  &.site-header .navbar__menu a {
+    color: var(--on-surface);
+    background: transparent;
+    border-radius: calc(var(--radius) * 0.75);
+    font-weight: 500;
+  }
+
+  &.site-header .navbar__menu a:hover,
+  &.site-header .navbar__menu a:focus-visible {
+    color: var(--brand);
+    background: unquote("rgb(from var(--brand) r g b / 12%)");
+  }
+
+  &.site-header .navbar__menu a.is-active {
+    background: unquote("rgb(from var(--brand) r g b / 18%)");
+    color: var(--brand);
+    box-shadow: inset 0 0 0 1px unquote("rgb(from var(--brand) r g b / 18%)");
+  }
+
+  &.site-header .dropdown-menu,
+  &.site-header .mega-menu {
+    background: var(--surface);
+    background: linear-gradient(180deg,
+        color-mix(in srgb, var(--surface) 96%, white 4%),
+        color-mix(in srgb, var(--surface) 92%, white 8%));
+    border-color: unquote("rgb(from var(--on-surface) r g b / 12%)");
+    box-shadow: 0 24px 60px unquote("rgb(from var(--on-surface) r g b / 14%)");
+  }
+
+  &.site-header .dropdown-menu a,
+  &.site-header .mega-menu__list a {
+    color: var(--on-surface);
+  }
+
+  &.site-header .dropdown-menu a:hover,
+  &.site-header .dropdown-menu a:focus-visible,
+  &.site-header .mega-menu__list a:hover,
+  &.site-header .mega-menu__list a:focus-visible {
+    background: unquote("rgb(from var(--brand) r g b / 12%)");
+    color: var(--brand);
+  }
+
+  &.site-header .lang-switcher__button {
+    color: var(--muted);
+    color: color-mix(in srgb, var(--on-surface) 72%, var(--muted) 28%);
+    background: transparent;
+  }
+
+  &.site-header .lang-switcher__button:hover,
+  &.site-header .lang-switcher__button:focus-visible {
+    background: unquote("rgb(from var(--on-surface) r g b / 8%)");
+  }
+
+  &.site-header .lang-switcher__dropdown {
+    background: var(--surface);
+    border-color: unquote("rgb(from var(--on-surface) r g b / 12%)");
+  }
+
+  &.site-header .navbar__toggler {
+    color: var(--on-surface);
+    background: unquote("rgb(from var(--on-surface) r g b / 8%)");
+    border-radius: calc(var(--radius) * 0.8);
+    box-shadow: inset 0 0 0 1px unquote("rgb(from var(--on-surface) r g b / 12%)");
+  }
+
+  &.site-header .navbar__toggler.open {
+    background: unquote("rgb(from var(--brand) r g b / 16%)");
+    color: var(--brand);
+  }
+
+  &.drawer-overlay {
+    background: unquote("rgb(from var(--on-surface) r g b / 45%)");
+  }
+
+  &.drawer {
+    background: var(--surface);
+    background: linear-gradient(180deg,
+        color-mix(in srgb, var(--surface) 96%, white 4%),
+        color-mix(in srgb, var(--surface) 90%, white 10%));
+    color: var(--on-surface);
+    box-shadow: 0 32px 60px unquote("rgb(from var(--on-surface) r g b / 16%)");
+  }
+
+  &.drawer :is(.drawer__title, .drawer__link, .drawer__sublink, .drawer__languages-toggle, .drawer__languages-list a) {
+    color: var(--on-surface);
+  }
+
+  &.drawer .drawer__link,
+  &.drawer .drawer__sublink,
+  &.drawer .drawer__languages-list a {
+    background: unquote("rgb(from var(--on-surface) r g b / 8%)");
+  }
+
+  &.drawer :is(.drawer__link:hover, .drawer__link:focus-visible, .drawer__sublink:hover, .drawer__sublink:focus-visible,
+      .drawer__languages-list a:hover, .drawer__languages-list a:focus-visible) {
+    background: unquote("rgb(from var(--brand) r g b / 16%)");
+    color: var(--brand);
+  }
+
+  &.drawer .drawer__panel-back,
+  &.drawer .drawer__arrow {
+    color: var(--muted);
+    color: color-mix(in srgb, var(--on-surface) 72%, var(--muted) 28%);
+  }
+
+  &.drawer .drawer__languages {
+    border-color: unquote("rgb(from var(--on-surface) r g b / 12%)");
+  }
 }
 
-.drawer__footer {
-  padding-top: calc(var(--space) * 4);
-  margin-top: auto;
-  border-top: var(--border-w) solid var(--border);
+// Variant 3 · Centered: editorial uppercase layout with underline accent
+.nav-theme--centered {
+  &.site-header {
+    background: var(--surface);
+    background: color-mix(in srgb, var(--surface) 82%, white 18%);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    box-shadow: 0 28px 80px rgba(15, 23, 42, 0.18);
+    border-bottom: none;
+  }
+
+  &.site-header .navbar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: calc(var(--space) * 3);
+  }
+
+  &.site-header .navbar__logo {
+    justify-self: flex-start;
+  }
+
+  &.site-header .navbar__menu {
+    justify-self: center;
+    justify-content: center;
+  }
+
+  &.site-header .navbar__actions {
+    justify-self: flex-end;
+    gap: calc(var(--space) * 3);
+  }
+
+  &.site-header .navbar__menu > ul {
+    gap: calc(var(--space) * 3);
+  }
+
+  &.site-header .navbar__menu a {
+    position: relative;
+    background: transparent;
+    color: var(--on-surface);
+    color: color-mix(in srgb, var(--on-surface) 88%, white 12%);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    padding-inline: calc(var(--space) * 2.5);
+  }
+
+  &.site-header .navbar__menu a::after {
+    content: "";
+    position: absolute;
+    left: 20%; right: 20%;
+    bottom: calc(var(--space) * -0.5);
+    height: 3px;
+    border-radius: var(--radius-pill);
+    background: linear-gradient(90deg, rgba(31, 99, 163, 0.25), rgba(31, 99, 163, 0.8));
+    opacity: 0;
+    transform: scaleX(0.6);
+    transition: opacity var(--t-normal) var(--ease), transform var(--t-normal) var(--ease);
+  }
+
+  &.site-header .navbar__menu a:hover::after,
+  &.site-header .navbar__menu a:focus-visible::after,
+  &.site-header .navbar__menu a.is-active::after {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  &.site-header .navbar__menu a.is-active {
+    color: var(--brand);
+  }
+
+  &.site-header .dropdown-menu,
+  &.site-header .mega-menu {
+    background: var(--surface);
+    background: color-mix(in srgb, var(--surface) 90%, white 10%);
+    border: none;
+    box-shadow: 0 32px 80px rgba(15, 23, 42, 0.16);
+  }
+
+  &.site-header .dropdown-menu a,
+  &.site-header .mega-menu__list a {
+    color: rgba(15, 23, 42, 0.86);
+  }
+
+  &.site-header .dropdown-menu a:hover,
+  &.site-header .mega-menu__list a:hover,
+  &.site-header .dropdown-menu a:focus-visible,
+  &.site-header .mega-menu__list a:focus-visible {
+    color: var(--brand);
+    background: rgba(31, 99, 163, 0.14);
+  }
+
+  &.site-header .lang-switcher__button {
+    color: rgba(15, 23, 42, 0.75);
+    font-weight: 600;
+  }
+
+  &.site-header .navbar__toggler {
+    color: rgba(15, 23, 42, 0.86);
+    border-radius: var(--radius-pill);
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    padding-inline: calc(var(--space) * 1.5);
+  }
+
+  &.drawer-overlay {
+    background: rgba(15, 23, 42, 0.5);
+  }
+
+  &.drawer {
+    background: var(--surface);
+    background: linear-gradient(180deg,
+        color-mix(in srgb, var(--surface) 94%, white 6%),
+        color-mix(in srgb, var(--surface) 88%, white 12%));
+    color: var(--on-surface);
+    color: color-mix(in srgb, var(--on-surface) 90%, white 10%);
+    box-shadow: 0 36px 80px rgba(15, 23, 42, 0.2);
+  }
+
+  &.drawer .drawer__title {
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  &.drawer .drawer__link,
+  &.drawer .drawer__sublink {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--on-surface);
+    color: color-mix(in srgb, var(--on-surface) 88%, white 12%);
+    background: unquote("rgb(from var(--brand) r g b / 12%)");
+  }
+
+  &.drawer .drawer__link:hover,
+  &.drawer .drawer__link:focus-visible,
+  &.drawer .drawer__sublink:hover,
+  &.drawer .drawer__sublink:focus-visible {
+    background: unquote("rgb(from var(--brand) r g b / 18%)");
+    color: var(--brand);
+  }
+
+  &.drawer .drawer__arrow {
+    color: rgba(15, 23, 42, 0.65);
+  }
+
+  &.drawer .drawer__languages {
+    border-color: rgba(15, 23, 42, 0.1);
+  }
 }
 
-.drawer__footer .lang-switcher__button {
-  width: 100%;
-  justify-content: center;
+// Variant 4 · Elevated: immersive gradient with pill navigation
+.nav-theme--elevated {
+  &.site-header {
+    background: linear-gradient(120deg, rgba(17, 94, 163, 0.95), rgba(32, 132, 198, 0.88));
+    color: var(--on-brand);
+    border-bottom: none;
+    box-shadow: 0 28px 70px rgba(22, 85, 145, 0.45);
+  }
+
+  &.site-header .navbar__menu > ul {
+    gap: calc(var(--space) * 2.5);
+  }
+
+  &.site-header .navbar__menu a {
+    color: var(--on-brand);
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: var(--radius-pill);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  }
+
+  &.site-header .navbar__menu a:hover,
+  &.site-header .navbar__menu a:focus-visible {
+    background: rgba(255, 255, 255, 0.22);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  }
+
+  &.site-header .navbar__menu a.is-active {
+    background: rgba(255, 255, 255, 0.3);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.24), 0 8px 20px rgba(12, 52, 93, 0.3);
+  }
+
+  &.site-header .dropdown-menu,
+  &.site-header .mega-menu {
+    background: linear-gradient(160deg, rgba(10, 32, 54, 0.95), rgba(13, 46, 74, 0.9));
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 32px 70px rgba(10, 34, 66, 0.5);
+  }
+
+  &.site-header .dropdown-menu a,
+  &.site-header .mega-menu__list a {
+    color: rgba(255, 255, 255, 0.92);
+  }
+
+  &.site-header .dropdown-menu a:hover,
+  &.site-header .mega-menu__list a:hover,
+  &.site-header .dropdown-menu a:focus-visible,
+  &.site-header .mega-menu__list a:focus-visible {
+    background: rgba(33, 143, 209, 0.22);
+    color: #fff;
+  }
+
+  &.site-header .mega-menu__title {
+    color: rgba(255, 255, 255, 0.92);
+  }
+
+  &.site-header .mega-menu__title.is-active {
+    color: #ffffff;
+  }
+
+  &.site-header .lang-switcher__button {
+    color: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-pill);
+    padding-inline: calc(var(--space) * 2);
+  }
+
+  &.site-header .lang-switcher__dropdown {
+    background: rgba(12, 37, 64, 0.96);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  &.site-header .lang-switcher__dropdown a:hover {
+    background: rgba(33, 143, 209, 0.28);
+  }
+
+  &.site-header .navbar__toggler {
+    color: var(--on-brand);
+    background: rgba(255, 255, 255, 0.14);
+    border-radius: var(--radius-pill);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  }
+
+  &.site-header .navbar__toggler.open {
+    background: rgba(255, 255, 255, 0.24);
+  }
+
+  &.drawer-overlay {
+    background: rgba(6, 17, 28, 0.68);
+  }
+
+  &.drawer {
+    background: linear-gradient(180deg, rgba(8, 26, 45, 0.96), rgba(9, 32, 58, 0.94));
+    color: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 36px 80px rgba(6, 24, 45, 0.5);
+  }
+
+  &.drawer :is(.drawer__title, .drawer__link, .drawer__sublink, .drawer__languages-toggle, .drawer__languages-list a) {
+    color: rgba(255, 255, 255, 0.92);
+  }
+
+  &.drawer .drawer__link,
+  &.drawer .drawer__sublink {
+    background: rgba(33, 143, 209, 0.22);
+  }
+
+  &.drawer :is(.drawer__link:hover, .drawer__link:focus-visible, .drawer__sublink:hover, .drawer__sublink:focus-visible) {
+    background: rgba(56, 170, 235, 0.32);
+    color: #ffffff;
+  }
+
+  &.drawer .drawer__panel-back,
+  &.drawer .drawer__arrow {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  &.drawer .drawer__languages {
+    border-color: rgba(255, 255, 255, 0.14);
+  }
+}
+
+body[data-nav-variant='centered'] {
+  --header-height: 80px;
+}
+
+body[data-nav-variant='elevated'] {
+  --header-height: 78px;
 }
 
 /*
@@ -527,5 +1197,28 @@ body[data-drawer-open='true'] {
 
   .navbar__toggler {
     display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header,
+  .navbar__menu a,
+  .dropdown-menu,
+  .mega-menu,
+  .lang-switcher__dropdown,
+  .navbar__toggler .toggler-bar,
+  .drawer,
+  .drawer-overlay,
+  .drawer__panel,
+  .drawer__link,
+  .drawer__sublink,
+  .drawer__panel-back,
+  .drawer__arrow,
+  .drawer__languages-toggle,
+  .drawer__languages-toggle svg,
+  .drawer__languages-list a {
+    transition: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,19 @@
-<header class="site-header" id="site-header">
+{{ $navScratch := newScratch }}
+{{ $navScratch.Set "variant" "classic" }}
+{{ with .Site.Params.navigation }}
+  {{ with .variant }}
+    {{ $navScratch.Set "variant" . }}
+  {{ end }}
+{{ end }}
+{{ with .Params.navigation }}
+  {{ with .variant }}
+    {{ $navScratch.Set "variant" . }}
+  {{ end }}
+{{ end }}
+{{ $navVariantRaw := $navScratch.Get "variant" }}
+{{ $navVariantSlug := default "classic" ($navVariantRaw | urlize) }}
+<header class="site-header nav-theme nav-theme--{{ $navVariantSlug }}" id="site-header" data-nav-theme
+  data-nav-variant="{{ $navVariantSlug }}" data-nav-variant-default="{{ $navVariantSlug }}">
   <nav class="navbar">
 
     <div class="navbar__logo">
@@ -15,7 +30,7 @@
         {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
         {{ $isProducts := eq .Identifier "products" }}
         <li class="{{ if .HasChildren }}has-dropdown{{ end }}{{ if $isProducts }} has-mega{{ end }}">
-          <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}"{{ if $active }} aria-current="page"{{ end }}>
             <span>{{ .Name }}</span>
             {{ if .HasChildren }}
             <svg class="dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
@@ -39,7 +54,7 @@
                 {{ $groupHasUrl := $group.URL }}
                 <div class="mega-menu__title-wrapper">
                   {{ if $groupHasUrl }}
-                  <a href="{{ $group.URL | relLangURL }}" class="mega-menu__title {{ if $groupActive }}is-active{{ end }}">{{ $group.Name }}</a>
+                  <a href="{{ $group.URL | relLangURL }}" class="mega-menu__title {{ if $groupActive }}is-active{{ end }}"{{ if $groupActive }} aria-current="page"{{ end }}>{{ $group.Name }}</a>
                   {{ else }}
                   <span class="mega-menu__title">{{ $group.Name }}</span>
                   {{ end }}
@@ -50,7 +65,7 @@
                   {{ range $group.Children }}
                   {{ $itemActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
                   <li>
-                    <a href="{{ .URL | relLangURL }}" class="{{ if $itemActive }}is-active{{ end }}">{{ .Name }}</a>
+                    <a href="{{ .URL | relLangURL }}" class="{{ if $itemActive }}is-active{{ end }}"{{ if $itemActive }} aria-current="page"{{ end }}>{{ .Name }}</a>
                   </li>
                   {{ end }}
                 </ul>
@@ -65,7 +80,7 @@
             {{ range .Children }}
             {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
             <li>
-              <a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a>
+              <a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}"{{ if $childActive }} aria-current="page"{{ end }}>{{ .Name }}</a>
             </li>
             {{ end }}
           </ul>
@@ -99,7 +114,7 @@
       </div>
       {{ end }}
 
-      <button class="navbar__toggler" id="drawer-toggler" aria-label="Open menu">
+      <button class="navbar__toggler" id="drawer-toggler" aria-label="Open menu" aria-expanded="false">
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
         <span class="toggler-bar"></span>
@@ -108,41 +123,114 @@
   </nav>
 </header>
 
-<div class="drawer-overlay" id="drawer-overlay"></div>
-<aside class="drawer" id="drawer">
+{{ $menuTitle := i18n "menu" | default "Menu" }}
+<div class="drawer-overlay nav-theme nav-theme--{{ $navVariantSlug }}" id="drawer-overlay" data-nav-theme
+  data-nav-variant="{{ $navVariantSlug }}"></div>
+<aside class="drawer nav-theme nav-theme--{{ $navVariantSlug }}" id="drawer" aria-hidden="true" data-nav-theme
+  data-nav-variant="{{ $navVariantSlug }}">
   <div class="drawer__header">
-    <span class="sr-only">Menu</span>
+    <button class="drawer__back" id="drawer-back" type="button" aria-label="{{ i18n "backToMenu" | default "Back to main menu" }}" hidden>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd"
+          d="M12.78 4.22a.75.75 0 010 1.06L8.56 9.5H16a.75.75 0 010 1.5H8.56l4.22 4.22a.75.75 0 11-1.06 1.06l-5.5-5.5a.75.75 0 010-1.06l5.5-5.5a.75.75 0 011.06 0z"
+          clip-rule="evenodd" />
+      </svg>
+    </button>
+    <span class="drawer__title" id="drawer-title" data-default="{{ $menuTitle }}">{{ $menuTitle }}</span>
   </div>
 
   <nav class="drawer__menu" aria-label="Mobile navigation">
     {{ $current := . }}
-    <ul>
-      {{ range .Site.Menus.main }}
-      {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
-          {{ range .Children }}
-          {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-          <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
+    <div class="drawer__panel is-active" id="panel-root" data-panel="root" data-title="{{ $menuTitle }}" aria-hidden="false">
+      <ul class="drawer__list">
+        {{ range .Site.Menus.main }}
+        {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+        {{ $panelKey := default .Name .Identifier }}
+        {{ $panelSlug := lower (replaceRE "[^a-zA-Z0-9]+" "-" $panelKey) }}
+        {{ $panelID := printf "panel-%s" $panelSlug }}
+        <li class="drawer__item drawer__item--root{{ if .HasChildren }} has-children{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $active }}is-active{{ end }}"{{ if $active }} aria-current="page"{{ end }}>
+            <span>{{ .Name }}</span>
+          </a>
+          {{ if .HasChildren }}
+          <button class="drawer__arrow" type="button" data-target="{{ $panelID }}" aria-controls="{{ $panelID }}"
+            aria-haspopup="true" aria-expanded="false" aria-label="{{ printf "View submenu for %s" .Name }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd"
+                d="M7.22 4.22a.75.75 0 011.06 0l5.5 5.5a.75.75 0 010 1.06l-5.5 5.5a.75.75 0 11-1.06-1.06L11.94 10 7.22 5.28a.75.75 0 010-1.06z"
+                clip-rule="evenodd" />
+            </svg>
+          </button>
           {{ end }}
-        </ul>
+        </li>
         {{ end }}
-      </li>
-      {{ end }}
-    </ul>
-  </nav>
+      </ul>
 
-  {{ if hugo.IsMultilingual }}
-  <div class="drawer__footer">
-    <div class="lang-switcher">
-      {{ range .Site.Home.AllTranslations }}
-      <a class="lang-switcher__button" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+      {{ if hugo.IsMultilingual }}
+      <div class="drawer__languages" data-languages>
+        <button class="drawer__languages-toggle" type="button" aria-expanded="false" data-languages-toggle aria-controls="drawer-languages-panel">
+          <span>{{ i18n "language" | default "Language" }}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clip-rule="evenodd" />
+          </svg>
+        </button>
+        <div class="drawer__languages-panel" id="drawer-languages-panel" data-languages-panel hidden>
+          <ul class="drawer__languages-list">
+            {{ range .Site.Home.AllTranslations }}
+            {{ if ne .Language.Lang $.Site.Language.Lang }}
+            <li>
+              <a class="drawer__link" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+            </li>
+            {{ end }}
+            {{ end }}
+          </ul>
+        </div>
+      </div>
       {{ end }}
     </div>
-  </div>
-  {{ end }}
+
+    {{ range .Site.Menus.main }}
+    {{ if .HasChildren }}
+    {{ $panelKey := default .Name .Identifier }}
+    {{ $panelSlug := lower (replaceRE "[^a-zA-Z0-9]+" "-" $panelKey) }}
+    {{ $panelID := printf "panel-%s" $panelSlug }}
+    <div class="drawer__panel{{ if eq .Identifier "products" }} drawer__panel--products{{ end }}" id="{{ $panelID }}" data-panel="{{ $panelID }}"
+      data-title="{{ .Name }}" aria-hidden="true" hidden>
+      <button class="drawer__panel-back" type="button" data-panel-back
+        aria-label="{{ i18n "backToMenu" | default "Back to main menu" }}">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd"
+            d="M12.78 4.22a.75.75 0 010 1.06L8.56 9.5H16a.75.75 0 010 1.5H8.56l4.22 4.22a.75.75 0 11-1.06 1.06l-5.5-5.5a.75.75 0 010-1.06l5.5-5.5a.75.75 0 011.06 0z"
+            clip-rule="evenodd" />
+        </svg>
+        <span class="sr-only">{{ i18n "menu" | default "Menu" }}</span>
+      </button>
+      <ul class="drawer__list">
+        {{ range .Children }}
+        {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+        <li class="drawer__item drawer__item--second{{ if .HasChildren }} has-children{{ end }}">
+          <a href="{{ .URL | relLangURL }}" class="drawer__link {{ if $childActive }}is-active{{ end }}"{{ if $childActive }} aria-current="page"{{ end }}>
+            <span>{{ .Name }}</span>
+          </a>
+          {{ if .HasChildren }}
+          <ul class="drawer__sublist">
+            {{ range .Children }}
+            {{ $grandActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+            <li>
+              <a href="{{ .URL | relLangURL }}" class="drawer__sublink {{ if $grandActive }}is-active{{ end }}"{{ if $grandActive }} aria-current="page"{{ end }}>{{ .Name }}</a>
+            </li>
+            {{ end }}
+          </ul>
+          {{ end }}
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+    {{ end }}
+  </nav>
 </aside>
 
 <script>
@@ -209,27 +297,189 @@
       handleSmartHeader();
     }
 
-    // --- 2. 抽屉 (Drawer) 逻辑 (保持不变) ---
+    // --- 2. 抽屉 (Drawer) 逻辑 ---
+    const drawer = document.getElementById('drawer');
     const drawerToggler = document.getElementById('drawer-toggler');
     const drawerOverlay = document.getElementById('drawer-overlay');
+    const drawerBack = document.getElementById('drawer-back');
+    const drawerTitle = document.getElementById('drawer-title');
+    const drawerPanels = drawer ? Array.from(drawer.querySelectorAll('[data-panel]')) : [];
+    const navThemeElements = Array.from(document.querySelectorAll('[data-nav-theme]'));
+    const navThemeClassPrefix = 'nav-theme--';
+    const navVariantDefault = header?.dataset.navVariantDefault || 'classic';
+    const rootPanel = drawer ? drawer.querySelector('[data-panel="root"]') : null;
+    const languageContainer = drawer ? drawer.querySelector('[data-languages]') : null;
+    const languageToggle = drawer ? drawer.querySelector('[data-languages-toggle]') : null;
+    const languagePanel = drawer ? drawer.querySelector('[data-languages-panel]') : null;
+    let activePanel = rootPanel;
+    const focusableSelector = 'a[href]:not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
+
+    const normalizeVariant = (value) => {
+      if (!value) return navVariantDefault;
+      return value
+        .toString()
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '') || navVariantDefault;
+    };
+
+    const applyNavVariant = (value) => {
+      const variant = normalizeVariant(value);
+      navThemeElements.forEach((element) => {
+        const classList = Array.from(element.classList);
+        classList
+          .filter((cls) => cls.startsWith(navThemeClassPrefix))
+          .forEach((cls) => element.classList.remove(cls));
+        element.classList.add(`${navThemeClassPrefix}${variant}`);
+        element.setAttribute('data-nav-variant', variant);
+      });
+      document.documentElement.setAttribute('data-nav-variant', variant);
+      document.body.setAttribute('data-nav-variant', variant);
+      return variant;
+    };
+
+    const isElementVisible = (element) => {
+      if (!element) return false;
+      return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
+    };
+
+    const focusFirstElement = (container) => {
+      if (!container) return;
+      const focusable = Array.from(container.querySelectorAll(focusableSelector)).filter(isElementVisible);
+      if (focusable.length) {
+        requestAnimationFrame(() => {
+          focusable[0].focus({ preventScroll: true });
+        });
+      }
+    };
+
+    applyNavVariant(navVariantDefault);
+    const navVariantParams = new URLSearchParams(window.location.search);
+    const requestedVariant = navVariantParams.get('nav')
+      || navVariantParams.get('navvariant')
+      || navVariantParams.get('nav-theme')
+      || navVariantParams.get('navstyle');
+    if (requestedVariant) {
+      applyNavVariant(requestedVariant);
+    }
+
+    window.__setNavVariant = (value) => applyNavVariant(value || navVariantDefault);
+    window.__getNavVariant = () => document.body.getAttribute('data-nav-variant');
+
+    const navVariantChoices = ['classic', 'minimal', 'centered', 'elevated'];
+    if (!navVariantChoices.includes(navVariantDefault)) {
+      navVariantChoices.unshift(navVariantDefault);
+    }
+    document.addEventListener('keydown', (event) => {
+      if (!event.shiftKey || !event.altKey || event.code !== 'KeyN') {
+        return;
+      }
+      event.preventDefault();
+      const currentVariant = document.body.getAttribute('data-nav-variant') || navVariantDefault;
+      const currentIndex = navVariantChoices.indexOf(currentVariant);
+      const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % navVariantChoices.length : 0;
+      applyNavVariant(navVariantChoices[nextIndex]);
+    });
+
+    const resetSubmenuTriggers = () => {
+      if (!drawer) return;
+      const triggers = drawer.querySelectorAll('.drawer__arrow[data-target]');
+      triggers.forEach((trigger) => {
+        trigger.setAttribute('aria-expanded', 'false');
+      });
+    };
+
+    const collapseLanguages = () => {
+      if (!languageContainer || !languageToggle || !languagePanel) return;
+      languageContainer.classList.remove('is-open');
+      languageToggle.setAttribute('aria-expanded', 'false');
+      languagePanel.hidden = true;
+    };
+
+    const showPanel = (panelId, { shouldFocus = true } = {}) => {
+      if (!drawer) return;
+      const target = typeof panelId === 'string'
+        ? drawer.querySelector(`[data-panel="${panelId}"]`)
+        : panelId;
+      if (!target) return;
+
+      drawerPanels.forEach((panel) => {
+        const isTarget = panel === target;
+        panel.classList.toggle('is-active', isTarget);
+        panel.toggleAttribute('hidden', !isTarget);
+        panel.setAttribute('aria-hidden', isTarget ? 'false' : 'true');
+      });
+
+      activePanel = target;
+      const isRoot = activePanel === rootPanel;
+      drawer.classList.toggle('drawer--submenu', !isRoot);
+
+      if (drawerBack) {
+        drawerBack.hidden = isRoot;
+      }
+
+      if (drawerTitle) {
+        const defaultTitle = drawerTitle.dataset.default || drawerTitle.textContent || '';
+        const panelTitle = activePanel.dataset.title || defaultTitle;
+        drawerTitle.textContent = panelTitle;
+      }
+
+      if (!isRoot) {
+        collapseLanguages();
+      }
+
+      if (shouldFocus) {
+        focusFirstElement(activePanel);
+      }
+    };
+
+    const resetDrawerState = () => {
+      collapseLanguages();
+      if (rootPanel) {
+        showPanel('root', { shouldFocus: false });
+      }
+      resetSubmenuTriggers();
+    };
+
+    const setTogglerState = (isOpen) => {
+      if (!drawerToggler) return;
+      drawerToggler.classList.toggle('open', isOpen);
+      drawerToggler.setAttribute('aria-expanded', String(isOpen));
+      drawerToggler.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+    };
 
     const openDrawer = () => {
       body.setAttribute('data-drawer-open', 'true');
-      if (drawerToggler) drawerToggler.classList.add('open');
+      if (drawer) {
+        drawer.setAttribute('aria-hidden', 'false');
+        resetDrawerState();
+      }
+      setTogglerState(true);
+      if (rootPanel) {
+        focusFirstElement(rootPanel);
+      }
     };
+
     const closeDrawer = () => {
       body.setAttribute('data-drawer-open', 'false');
-      if (drawerToggler) drawerToggler.classList.remove('open');
+      if (drawer) {
+        drawer.setAttribute('aria-hidden', 'true');
+        resetDrawerState();
+      }
+      setTogglerState(false);
+      if (drawerToggler) {
+        drawerToggler.focus({ preventScroll: true });
+      }
     };
 
     if (drawerToggler) {
+      drawerToggler.setAttribute('aria-expanded', 'false');
       drawerToggler.addEventListener('click', () => {
         const isOpen = body.getAttribute('data-drawer-open') === 'true';
         if (isOpen) {
-          // 关闭抽屉
           closeDrawer();
         } else {
-          // 打开抽屉
           openDrawer();
         }
       });
@@ -239,10 +489,77 @@
       drawerOverlay.addEventListener('click', closeDrawer);
     }
 
+    if (drawerBack) {
+      drawerBack.addEventListener('click', () => {
+        showPanel('root');
+        resetSubmenuTriggers();
+      });
+    }
+
+    if (drawer && drawerPanels.length) {
+      const submenuTriggers = drawer.querySelectorAll('.drawer__arrow[data-target]');
+      submenuTriggers.forEach((button) => {
+        button.addEventListener('click', () => {
+          const panelId = button.getAttribute('data-target');
+          if (panelId) {
+            resetSubmenuTriggers();
+            button.setAttribute('aria-expanded', 'true');
+            showPanel(panelId);
+          }
+        });
+      });
+
+      const panelBackButtons = drawer.querySelectorAll('[data-panel-back]');
+      panelBackButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          showPanel('root');
+          resetSubmenuTriggers();
+        });
+      });
+    }
+
+    if (languageToggle && languagePanel && languageContainer) {
+      languagePanel.hidden = true;
+      languageToggle.addEventListener('click', () => {
+        const isExpanded = languageToggle.getAttribute('aria-expanded') === 'true';
+        const nextState = !isExpanded;
+        languageToggle.setAttribute('aria-expanded', String(nextState));
+        languageContainer.classList.toggle('is-open', nextState);
+        languagePanel.hidden = !nextState;
+      });
+    }
+
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && body.getAttribute('data-drawer-open') === 'true') {
+      const isDrawerOpen = body.getAttribute('data-drawer-open') === 'true';
+      if (!isDrawerOpen) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
         closeDrawer();
+        return;
+      }
+
+      if (event.key === 'Tab' && drawer) {
+        const focusable = Array.from(drawer.querySelectorAll(focusableSelector)).filter(isElementVisible);
+        if (!focusable.length) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+
+        if (event.shiftKey) {
+          if (active === first || !drawer.contains(active)) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     });
+
+    resetDrawerState();
   });
 </script>


### PR DESCRIPTION
## Summary
- add a navigation variant selector that reads from configuration, syncs the drawer/overlay, and supports querystring overrides and an Alt+Shift+N preview shortcut
- define four polished SCSS skins (classic, minimal, centered, elevated) covering desktop and drawer treatments with responsive, multi-column product layouts
- expose helpers on `window` for manual switching and preserve accessibility, language toggles, and focus management across variants

## Testing
- Not run (Hugo CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e5b7f509f4832cac5c94e7b712192f