### PR TITLE
Fix dropdown menu spacing in navigation

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -115,7 +115,7 @@ body.header-hidden {
 
 .dropdown-menu {
   position: absolute;
-  top: calc(100% + calc(var(--space) * 2));
+  top: 100%;
   left: 0;
   min-width: 200px;
   background-color: var(--surface);


### PR DESCRIPTION
## Summary
- align the main navigation dropdown menu directly beneath the parent link by removing the extra top spacing

## Testing
- not run (static change)

------
https://chatgpt.com/codex/tasks/task_e_68e620843a0c832ca5952d7f6af082f6