### PR TITLE
feat: add collapsible drawer submenus

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -351,6 +351,53 @@ body[data-drawer-open='true'] {
   overflow-y: auto;
 }
 
+.drawer__link-wrapper {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space) * 2);
+}
+
+.drawer__link-wrapper > a {
+  flex: 1;
+}
+
+.drawer__menu .has-submenu {
+  position: relative;
+}
+
+.submenu-toggle {
+  border: none;
+  background: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--space) * 2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease);
+}
+
+.submenu-toggle:hover,
+.submenu-toggle:focus-visible {
+  background-color: color-mix(in oklch, var(--surface), var(--on-surface) 12%);
+}
+
+.submenu-toggle:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.submenu-toggle .dropdown-arrow {
+  width: 1.5rem;
+  height: 1.5rem;
+  transition: transform var(--t-normal) var(--ease);
+}
+
+.drawer__menu .has-submenu.is-open .submenu-toggle .dropdown-arrow {
+  transform: rotate(180deg);
+}
+
 .drawer__menu ul {
   list-style: none;
   padding: 0;
@@ -383,11 +430,18 @@ body[data-drawer-open='true'] {
 .drawer__menu .submenu {
   padding-left: calc(var(--space) * 4);
   margin-top: calc(var(--space) * -1);
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height var(--t-normal) var(--ease);
 }
 
 .drawer__menu .submenu a {
   font-size: var(--fs-1);
   padding-block: calc(var(--space) * 2);
+}
+
+.drawer__menu .submenu[hidden] {
+  display: none;
 }
 
 .drawer__footer {

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -24,3 +24,4 @@ read_more = "阅读全文"
 submit = "发送信息"
 tags = "标签"
 
+toggle_submenu = "Toggle submenu"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -26,3 +26,4 @@ submit = "发送信息"
 social_title = "社交媒体"
 tags = "标签"
 
+toggle_submenu = "切换子菜单"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -82,13 +82,29 @@
   <nav class="drawer__menu" aria-label="Mobile navigation">
     {{ $current := . }}
     <ul>
-      {{ range .Site.Menus.main }}
-      {{ $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
-      <li>
-        <a href="{{ .URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ .Name }}</a>
-        {{ if .HasChildren }}
-        <ul class="submenu">
-          {{ range .Children }}
+      {{ range $index, $item := .Site.Menus.main }}
+      {{ $active := or ($current.IsMenuCurrent "main" $item) ($current.HasMenuCurrent "main" $item) }}
+      <li class="{{ if $item.HasChildren }}has-submenu{{ end }}{{ if and $item.HasChildren $active }} is-open{{ end }}">
+        <div class="drawer__link-wrapper">
+          <a href="{{ $item.URL | relLangURL }}" class="{{ if $active }}is-active{{ end }}">{{ $item.Name }}</a>
+          {{ if $item.HasChildren }}
+          {{ $submenuID := printf "drawer-submenu-%d" $index }}
+          <button class="submenu-toggle" type="button" aria-controls="{{ $submenuID }}"
+            aria-expanded="{{ if $active }}true{{ else }}false{{ end }}"
+            aria-label="{{ with i18n "toggle_submenu" }}{{ . }}{{ else }}{{ printf "切换%s子菜单" $item.Name }}{{ end }}">
+            <svg class="dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+              aria-hidden="true">
+              <path fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                clip-rule="evenodd" />
+            </svg>
+          </button>
+          {{ end }}
+        </div>
+        {{ if $item.HasChildren }}
+        {{ $submenuID := printf "drawer-submenu-%d" $index }}
+        <ul class="submenu" id="{{ $submenuID }}" {{ if not $active }}hidden{{ end }}>
+          {{ range $item.Children }}
           {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
           <li><a href="{{ .URL | relLangURL }}" class="{{ if $childActive }}is-active{{ end }}">{{ .Name }}</a></li>
           {{ end }}
@@ -208,6 +224,73 @@
       if (event.key === 'Escape' && body.getAttribute('data-drawer-open') === 'true') {
         closeDrawer();
       }
+    });
+
+    const drawerSubmenus = document.querySelectorAll('.drawer__menu .has-submenu');
+
+    drawerSubmenus.forEach((item) => {
+      const toggleBtn = item.querySelector('.submenu-toggle');
+      const submenu = item.querySelector('.submenu');
+
+      if (!toggleBtn || !submenu) return;
+
+      const openSubmenu = () => {
+        submenu.hidden = false;
+        const height = submenu.scrollHeight;
+        submenu.style.maxHeight = `${height}px`;
+        item.classList.add('is-open');
+        toggleBtn.setAttribute('aria-expanded', 'true');
+
+        const handleOpenTransitionEnd = (event) => {
+          if (event.propertyName !== 'max-height') return;
+          submenu.style.maxHeight = 'none';
+          submenu.removeEventListener('transitionend', handleOpenTransitionEnd);
+        };
+
+        submenu.addEventListener('transitionend', handleOpenTransitionEnd);
+      };
+
+      const closeSubmenu = () => {
+        const height = submenu.scrollHeight;
+        submenu.style.maxHeight = `${height}px`;
+
+        requestAnimationFrame(() => {
+          submenu.style.maxHeight = '0px';
+        });
+
+        item.classList.remove('is-open');
+        toggleBtn.setAttribute('aria-expanded', 'false');
+
+        const handleCloseTransitionEnd = (event) => {
+          if (event.propertyName !== 'max-height') return;
+          submenu.hidden = true;
+          submenu.style.maxHeight = '';
+          submenu.removeEventListener('transitionend', handleCloseTransitionEnd);
+        };
+
+        submenu.addEventListener('transitionend', handleCloseTransitionEnd);
+      };
+
+      const isInitiallyExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+
+      if (isInitiallyExpanded) {
+        submenu.hidden = false;
+        submenu.style.maxHeight = 'none';
+        item.classList.add('is-open');
+      } else {
+        submenu.hidden = true;
+        submenu.style.maxHeight = '0px';
+        item.classList.remove('is-open');
+      }
+
+      toggleBtn.addEventListener('click', () => {
+        const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+        if (isExpanded) {
+          closeSubmenu();
+        } else {
+          openSubmenu();
+        }
+      });
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- convert the mobile drawer navigation menu to use toggle buttons so child links slide open below their parent
- add styling and transitions for the new submenu toggles and animated dropdown behavior
- provide i18n strings for the submenu toggle accessibility label in both locales

## Testing
- hugo *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e623622b3c832ca8c0036a79972e11